### PR TITLE
Switch to Pod::Simple::XHTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you wish to run the library.
 * [.creole](http://wikicreole.org/) -- `gem install creole`
 * [.rst](http://docutils.sourceforge.net/rst.html) -- `easy_install docutils`
 * [.asciidoc](http://www.methods.co.nz/asciidoc/) -- `brew install asciidoc`
-* [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`
+* [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::XHTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.
 * .1 - Requires [`groff`](http://www.gnu.org/software/groff/)
 

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -22,13 +22,5 @@ command(:rest2html, /re?st(\.txt)?/)
 
 command('asciidoc -s --backend=xhtml11 -o - -', /asciidoc/)
 
-# pod2html is nice enough to generate a full-on HTML document for us,
-# so we return the favor by ripping out the good parts.
-#
-# Any block passed to `command` will be handed the command's STDOUT for
-# post processing.
-command("/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go", /pod/) do |rendered|
-  if rendered =~ /<!-- start doc -->\s*(.+)\s*<!-- end doc -->/mi
-    $1
-  end
-end
+command("/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer:", /pod/)
+


### PR DESCRIPTION
I strongly recommend Pod::Simple::XHTML over Pod::Simple::HTML. The HTML it generates is much cleaner, and you don't have to strip out the header and footer like you did with the hack that was there before. The one downside is that Pod::Simple 3.11 is required for it to be valid XHML (a bunch of bugs were fixed in that version). But overall it's just much cleaner to use.
