### PR TITLE
adding mediawiki support

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -18,6 +18,10 @@ markup(:creole, /creole/) do |content|
   Creole.creolize(content)
 end
 
+markup(:wikicloth, /mediawiki|wiki/) do |content|
+  WikiCloth::WikiCloth.new({:data => content}).to_html
+end
+
 command(:rest2html, /re?st(\.txt)?/)
 
 command('asciidoc -s --backend=xhtml11 -o - -', /asciidoc/)

--- a/test/markups/README.mediawiki
+++ b/test/markups/README.mediawiki
@@ -1,0 +1,24 @@
+[[Home|&raquo; JRuby Project Wiki Home Page]]
+<h1>Embedding JRuby</h1>
+Using Java from Ruby is JRuby's best-known feature---but you can also go in the other direction, and use Ruby from Java.  There are several different ways to do this. You can execute entire Ruby scripts, call individual Ruby methods, or even implement a Java interface in Ruby (thus allowing you to treat Ruby objects like Java ones).  We refer to all these techniques generically as "embedding."  This section will explain how to embed JRuby in your Java project.
+
+__TOC__
+
+= Red Bridge (JRuby Embed) =
+
+JRuby has long had a private embedding API, which was closely tied to the runtime's internals and therefore changed frequently as JRuby evolved. Since version 1.4, however, we have also provided a more stable public API, known as Red Bridge or JRuby Embed. Existing Java programs written to the [[DirectJRubyEmbedding|legacy API]] should still work, but we strongly recommend Red Bridge for all new projects.
+
+== Features of Red Bridge ==
+Red Bridge consists of two layers: Embed Core on the bottom, and implementations of [http://www.jcp.org/en/jsr/detail?id=223 JSR223] and [http://jakarta.apache.org/bsf/ BSF] on top. Embed Core is JRuby-specific, and can take advantage of much of JRuby's power. JSR223 and BSF are more general interfaces that provide a common ground across scripting languages.
+
+Which API should you use? For projects where Ruby is the only scripting language involved, we recommend Embed Core for the following reasons:
+
+# With Embed Core, you can create several Ruby environments in one JVM, and configure them individually (via <code>org.jruby.RubyInstanceConfig</code>. With the other APIs, configuration options can only be set globally, via the <code>System</code> properties.
+# Embed Core offers several shortcuts, such as loading scripts from a <code>java.io.InputStream</code>, or returning Java-friendly objects from Ruby code. These allow you to skip a lot of boilerplate.
+
+For projects requiring multiple scripting languages, JSR223 is a good fit. Though the API is language-independent, JRuby's implementation of it allows you to set some Ruby-specific options. In particular, you can control the threading model of the scripting engine, the lifetime of local variables, compilation mode, and how line numbers are displayed.
+
+The full [http://jruby-embed.kenai.com/docs/ API documentation] has all the gory details. It's worth talking about a couple of the finer points here.
+
+= Previous Embedding JRuby Page=
+We recommend using Embed Core; however, if you're maintaining code that uses the old API, you can find its documentation on the [[JavaIntegration|legacy embedding]] page.

--- a/test/markups/README.mediawiki.html
+++ b/test/markups/README.mediawiki.html
@@ -1,0 +1,35 @@
+<p>
+<a href="javascript:void(0)">&raquo; JRuby Project Wiki Home Page</a>
+
+<h1>Embedding JRuby</h1>
+
+Using Java from Ruby is JRuby's best-known feature---but you can also go in the other direction, and use Ruby from Java.  There are several different ways to do this. You can execute entire Ruby scripts, call individual Ruby methods, or even implement a Java interface in Ruby (thus allowing you to treat Ruby objects like Java ones).  We refer to all these techniques generically as "embedding."  This section will explain how to embed JRuby in your Java project.
+
+</p><p>
+<table id="toc" class="toc" summary="Contents"><tr><td><div style="font-weight:bold">Table of Contents</div><ul></ul></td></tr></table>
+
+</p><p>
+<h1><span class="editsection">&#91;<a href="?section=Red_Bridge_JRuby_Embed">edit</a>&#93;</span> <span class="mw-headline" id="Red_Bridge_JRuby_Embed">Red Bridge (JRuby Embed)</span></h1>
+
+JRuby has long had a private embedding API, which was closely tied to the runtime's internals and therefore changed frequently as JRuby evolved. Since version 1.4, however, we have also provided a more stable public API, known as Red Bridge or JRuby Embed. Existing Java programs written to the <a href="javascript:void(0)">legacy API</a> should still work, but we strongly recommend Red Bridge for all new projects.
+
+</p><p>
+<h2><span class="editsection">&#91;<a href="?section=Features_of_Red_Bridge">edit</a>&#93;</span> <span class="mw-headline" id="Features_of_Red_Bridge">Features of Red Bridge</span></h2>Red Bridge consists of two layers: Embed Core on the bottom, and implementations of <a href="http://www.jcp.org/en/jsr/detail?id=223">JSR223</a> and <a href="http://jakarta.apache.org/bsf/">BSF</a> on top. Embed Core is JRuby-specific, and can take advantage of much of JRuby's power. JSR223 and BSF are more general interfaces that provide a common ground across scripting languages.
+
+</p><p>
+Which API should you use? For projects where Ruby is the only scripting language involved, we recommend Embed Core for the following reasons:
+
+</p><p>
+<ol><li> With Embed Core, you can create several Ruby environments in one JVM, and configure them individually (via <code>org.jruby.RubyInstanceConfig</code>. With the other APIs, configuration options can only be set globally, via the <code>System</code> properties.
+
+</li><li> Embed Core offers several shortcuts, such as loading scripts from a <code>java.io.InputStream</code>, or returning Java-friendly objects from Ruby code. These allow you to skip a lot of boilerplate.
+
+</p><p>
+</li></ol> For projects requiring multiple scripting languages, JSR223 is a good fit. Though the API is language-independent, JRuby's implementation of it allows you to set some Ruby-specific options. In particular, you can control the threading model of the scripting engine, the lifetime of local variables, compilation mode, and how line numbers are displayed.
+
+</p><p>
+The full <a href="http://jruby-embed.kenai.com/docs/">API documentation</a> has all the gory details. It's worth talking about a couple of the finer points here.
+
+</p><p>
+<h1><span class="editsection">&#91;<a href="?section=Previous_Embedding_JRuby_Page">edit</a>&#93;</span> <span class="mw-headline" id="Previous_Embedding_JRuby_Page">Previous Embedding JRuby Page</span></h1>We recommend using Embed Core; however, if you're maintaining code that uses the old API, you can find its documentation on the <a href="javascript:void(0)">legacy embedding</a> page.
+</p>


### PR DESCRIPTION
I'm helping jruby project to migrate from kenai wiki to github's wiki (gollum)

For this to happen, gollum should support mediawiki, so here is the pull request :)
