### PR TITLE
ability to determine markup format from file variables

### DIFF
--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -12,7 +12,10 @@ module GitHub
     def render(filename, content = nil)
       content ||= File.read(filename)
 
-      if proc = renderer(filename)
+      secondlf = content.index("\n", (content.index("\n") or -1) + 1)
+      head = content[0..(secondlf or -1)]
+
+      if proc = renderer(filename, head)
         proc[content]
       else
         content
@@ -59,9 +62,11 @@ module GitHub
       !!renderer(filename)
     end
 
-    def renderer(filename)
+    def renderer(filename, head = nil)
       @@markups.each do |key, value|
         if Regexp.compile("\\.(#{key})$") =~ filename
+          return value
+        elsif head and Regexp.compile("-\*-.*mode: ?(#{key}).*-\*-") =~ head
           return value
         end
       end

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -4,7 +4,7 @@ require 'github/markup'
 require 'test/unit'
 
 class MarkupTest < Test::Unit::TestCase
-  Dir['test/markups/README.*'].each do |readme|
+  Dir['test/markups/README*'].each do |readme|
     next if readme =~ /html$/
     markup = readme.split('/').last.gsub(/^README\./, '')
 

--- a/test/markups/README
+++ b/test/markups/README
@@ -1,0 +1,7 @@
+.. -*- mode: rst -*-
+
+Example without extension
+=========================
+
+It works, yahoo!
+

--- a/test/markups/README.html
+++ b/test/markups/README.html
@@ -1,0 +1,7 @@
+<div class="document">
+<div class="section" id="example-without-extension">
+<h1>Example without extension</h1>
+<p>It works, yahoo!</p>
+</div>
+</div>
+


### PR DESCRIPTION
It would be really nice to have ability to name README as just README without any extensions, putting file format declaration in so-called file variables, like:

```
.. -*- mode: rst -*-
# -*- mode: markdown -*-
```

I believe that file variables are used widely enough to make them recognizable (i.e. they are used by Python to determine source file encoding).

I'm not sure my code is good enough for you, but I'm not used to writing Ruby unfortunately. If the request as a whole makes sense, but implementation is questionable, I'll be glad to fix it.
