### PR TITLE
README.pdc

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ you wish to run the library.
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.
 * .1 - Requires [`groff`](http://www.gnu.org/software/groff/)
+* [.pandoc](http://johnmacfarlane.net/pandoc/) (LaTeX support uses the
+  Google Chart API) -- `cabal install pandoc`
 
 
 Contributing

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -26,6 +26,8 @@ command(:rest2html, /re?st(\.txt)?/)
 
 command('asciidoc -s --backend=xhtml11 -o - -', /asciidoc/)
 
+command('pandoc -S --webtex', /pandoc|pdc/)
+
 # pod2html is nice enough to generate a full-on HTML document for us,
 # so we return the favor by ripping out the good parts.
 #

--- a/test/markups/README.pdc
+++ b/test/markups/README.pdc
@@ -1,0 +1,17 @@
+# Hello world
+
+Hello everyone, what are the haps
+
+hap
+  :     An occurrence or happening, especially an unexpected, random or chance event.
+
+        (thx, wiktionary)
+
+
+## MathML
+
+Here's some maths!
+
+$$
+  \iint \sin x \; \textrm{d} x = - \sin x
+$$

--- a/test/markups/README.pdc.html
+++ b/test/markups/README.pdc.html
@@ -1,0 +1,31 @@
+<h1 id="hello-world"
+>Hello world</h1
+><p
+>Hello everyone, what are the haps</p
+><dl
+><dt
+  >hap</dt
+  ><dd
+  ><pre
+    ><code
+      >An occurrence or happening, especially an unexpected, random or chance event.
+
+(thx, wiktionary)
+</code
+      ></pre
+    ></dd
+  ></dl
+><h2 id="mathml"
+>MathML</h2
+><p
+>Here’s some maths!</p
+><p
+><br
+   /><img src="http://chart.apis.google.com/chart?cht=tx&amp;chl=%0A%20%20%5Ciint%20%5Csin%20x%20%5C%3B%20%5Ctextrm%7Bd%7D%20x%20%3D%20-%20%5Csin%20x%0A" alt="
+  \iint \sin x \; \textrm{d} x = - \sin x
+" title="
+  \iint \sin x \; \textrm{d} x = - \sin x
+"
+   /><br
+   /></p
+>


### PR DESCRIPTION
Pandoc support. Like Markdown, but with extras, like LaTeX and definition lists and things. (Admittedly, I don’t know how much if any of this the md filter you already have does, so sorry if this patch isn’t particularly useful…)
