### PR TITLE
restructuredText inline code

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 """A small wrapper file for parsing ReST files at GitHub."""
 


### PR DESCRIPTION
Hi,

I just reformatted my README from Markdown to restructuredText in order to get cross-referencing support and I stumbled on peculiar rendering bug.

In Markdown in you use the `` back-tick characters the text gets nicely formatted, but in rst when you use the ````double back-ticks (same feature) it does not properly highlight the in-lined code. The reason being is the rst renderer uses the `<tt>` HTML tag instead of the `<code>` tags.

So I have made a small change to the rst HTML renderer so that in-line code elements get rendered using the code tag.

It would be nice if you integrated these changes into GitHub, because not having the code highlighted makes documentation less readable.

Thomas
