### PR TITLE
Allow .mdwn extension for Markdown files, as used by Ikiwiki.

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -1,4 +1,4 @@
-markup(:markdown, /md|mkdn?|mdown|markdown/) do |content|
+markup(:markdown, /md|mkdn?|mdwn|mdown|markdown/) do |content|
   Markdown.new(content).to_html
 end
 


### PR DESCRIPTION
Commit by Jamey Sharp and Josh Triplett.
