### PR TITLE
require 'rubygems' in bin/github-markup

### DIFF
--- a/bin/github-markup
+++ b/bin/github-markup
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH.unshift File.dirname(__FILE__) + "/../lib"
+require 'rubygems'
 require 'github/markup'
 
 if ARGV[0] && File.exists?(file = ARGV[0])


### PR DESCRIPTION
I run `bin/github-markup test.markdown`, but see raw content instead of html.
This script needs to `require 'rubygems'` before `require 'github/markup'`, and then gets correctly html result.
