### PR TITLE
Add URL for redcarpet library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Markups
 The following markups are supported.  The dependencies listed are required if
 you wish to run the library.
 
-* [.markdown](http://daringfireball.net/projects/markdown/) -- `gem install redcarpet`
+* [.markdown](http://daringfireball.net/projects/markdown/) -- `gem install redcarpet` (https://github.com/tanoku/redcarpet)
 * [.textile](http://www.textism.com/tools/textile/) -- `gem install RedCloth`
 * [.rdoc](http://rdoc.sourceforge.net/) -- `gem install rdoc -v 3.6.1`
 * [.org](http://orgmode.org/) -- `gem install org-ruby`


### PR DESCRIPTION
Add URL for redcarpet library, since it's not obvious how to get there from Daring Fireball.
