### PR TITLE
Create pull request directly, instead of opening issue with a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ Contributing
 2. Create a branch (`git checkout -b my_markup`)
 3. Commit your changes (`git commit -am "Added Snarkdown"`)
 4. Push to the branch (`git push origin my_markup`)
-5. Create an [Issue][1] with a link to your branch
+5. Open a [Pull Request][1]
 6. Enjoy a refreshing Diet Coke and wait
 
 
 [r2h]: http://github.com/github/markup/tree/master/lib/github/commands/rest2html
 [r2hc]: http://github.com/github/markup/tree/master/lib/github/markups.rb#L13
-[1]: http://github.com/github/markup/issues
+[1]: http://github.com/github/markup/pulls


### PR DESCRIPTION
Instead of asking people to open issues with links, why not directly open pull requests :)
