### PR TITLE
Improve appearance of table of contents with reST

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -24,7 +24,8 @@ SETTINGS = {
     'file_insertion_enabled': False,
     'raw_enabled': False,
     'strip_comments': True,
-    'doctitle_xform': False,
+    'doctitle_xform': True,
+    'initial_header_level': 2,
     'report_level': 5,
 }
 


### PR DESCRIPTION
Tables of contents with reST are currently ugly.  (See, e.g., [this](https://github.com/rschroll/prsannots/blob/master/README.rst).)  There are several problems; one of them is that the top-level heading is included in the table of contents, even if it is acting as a header.  Turning doctitle_xform on fixes that, but makes the next-lower header rise up to &lt;h1>.  Changing initial_header_level pushes it back to &lt;h2>.
