### PR TITLE
Add some code blocks (new feature in docutils 0.9) to test syntax highlighting

### DIFF
--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -11,3 +11,39 @@ Header 2
 2. More ``code``, hooray
 
 3. Somé UTF-8°
+
+Some Python code
+----------------
+
+.. code:: python
+
+    import sys
+
+    def foo():
+        print("Hello there!")
+
+    foo()
+
+Some Ruby code
+----------------
+
+.. code:: ruby
+
+    def test_fails_gracefully_on_missing_env_commands
+        GitHub::Markup.command('/usr/bin/env totally_fake', /tf/)
+        text = 'hey mang'
+        assert GitHub::Markup.can_render?('README.tf')
+        actual = GitHub::Markup.render('README.tf', text)
+        assert_equal text, actual
+    end
+
+some PHP code
+-------------
+
+.. code:: php
+
+    <?php
+
+    $foo = 1;
+    $bar = 2;
+


### PR DESCRIPTION
The recently released [docutils 0.9](http://pypi.python.org/pypi/docutils/0.9) now supports a "code" directive, [as described here](http://docutils.sourceforge.net/docs/ref/rst/directives.html#code). If you guys upgrade your docutils to 0.9 and make sure that you have [Pygments](http://pypi.python.org/pypi/Pygments/1.5) installed, then you will get this feature for free and that would be awesome to have syntax highlighting in RST documentation.

This pull request adds sample code blocks to the RST files in your tests.

```
.. code:: python

 def my_function():
     "just a test"
     print 8/2
```
