### PR TITLE
Add support for code highlighting for asciidoc, this require installed p...

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -42,7 +42,7 @@ end
 
 command(:rest2html, /re?st(\.txt)?/)
 
-command('asciidoc -s --backend=xhtml11 -o - -', /asciidoc/)
+command('asciidoc -a pygments --filter=code --filter=source -s --backend=xhtml11 -o - -', /asciidoc/)
 
 # pod2html is nice enough to generate a full-on HTML document for us,
 # so we return the favor by ripping out the good parts.


### PR DESCRIPTION
Hi,

This add's support for code highlighting for asciidoc using pymentize library. I have tested it with gollum and it works fine.
