### PR TITLE
Support RD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 gem "redcarpet"
 gem "RedCloth"
+gem "rdtool"
 gem "rdoc", "~>3.6"
 gem "org-ruby", ">= 0.7.0"
 gem "creole", "~>0.3.6"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ you wish to run the library.
 
 * [.markdown, .mdown, .md](http://daringfireball.net/projects/markdown/) -- `gem install redcarpet` (https://github.com/vmg/redcarpet)
 * [.textile](http://www.textism.com/tools/textile/) -- `gem install RedCloth`
+* [.rd](http://uwabami.github.com/rdtool/) -- `gem install rdtool`
 * [.rdoc](http://rdoc.sourceforge.net/) -- `gem install rdoc -v 3.6.1`
 * [.org](http://orgmode.org/) -- `gem install org-ruby`
 * [.creole](http://wikicreole.org/) -- `gem install creole`

--- a/github-markup.gemspec
+++ b/github-markup.gemspec
@@ -66,6 +66,7 @@ desc
     lib/github/commands/asciidocapi.py
     lib/github/commands/rest2html
     lib/github/markup.rb
+    lib/github/markup/rd.rb
     lib/github/markup/rdoc.rb
     lib/github/markups.rb
     test/markup_test.rb
@@ -83,6 +84,8 @@ desc
     test/markups/README.org.html
     test/markups/README.pod
     test/markups/README.pod.html
+    test/markups/README.rd
+    test/markups/README.rd.html
     test/markups/README.rdoc
     test/markups/README.rdoc.html
     test/markups/README.rst
@@ -93,6 +96,8 @@ desc
     test/markups/README.textile.html
     test/markups/README.txt
     test/markups/README.txt.html
+    test/markups/README_no_begin_end.rd
+    test/markups/README_no_begin_end.rd.html
   ]
   # = MANIFEST =
 

--- a/lib/github/markup/rd.rb
+++ b/lib/github/markup/rd.rb
@@ -1,0 +1,82 @@
+require "English"
+
+require "rd/rdfmt"
+require "rd/rd2html-lib"
+
+module GitHub
+  module Markup
+    class RD
+      def initialize(content)
+        @content = content
+      end
+
+      def to_html
+        if /^=begin/ =~ @content
+          content = @content
+        else
+          content = "=begin\n#{@content}\n=end\n"
+        end
+        tree = ::RD::RDTree.new(content)
+        visitor = RD2HTMLContentOnlyVisitor.new
+        visitor.visit(tree)
+      end
+
+      class RD2HTMLContentOnlyVisitor < ::RD::RD2HTMLVisitor
+        def apply_to_DocumentElement(element, contents)
+          body = remove_rd_label_comments(contents.join("\n"))
+          [body, make_foottext].compact.join("\n") + "\n"
+        end
+
+        private
+        def remove_rd_label_comments(content)
+          content.gsub(/<!-- RDLabel: .+? -->/, "")
+        end
+
+        # id attribute value should match Name syntax in XML.
+        # See also: http://www.w3.org/TR/REC-xml/#NT-Name
+        XML_NAME_START_CHAR = /
+          : |
+          [A-Z] |
+          _ |
+          [a-z] |
+          [\u00C0-\u00D6] |
+          [\u00D8-\u00F6] |
+          [\u00F8-\u02FF] |
+          [\u0370-\u037D] |
+          [\u037F-\u1FFF] |
+          [\u200C-\u200D] |
+          [\u2070-\u218F] |
+          [\u2C00-\u2FEF] |
+          [\u3001-\uD7FF] |
+          [\uF900-\uFDCF] |
+          [\uFDF0-\uFFFD] |
+          [\u10000-\uEFFFF]
+        /x
+        XML_NAME_CHAR = /
+          #{XML_NAME_START_CHAR} |
+          - |
+          \. |
+          [0-9] |
+          \u00B7 |
+          [\u0300-\u036F] |
+          [\u203F-\u2040]
+        /x
+        def get_anchor(element)
+          label = element.label
+          return super if label.nil?
+
+          space_compressed_label = label.gsub(/ +/, "-")
+          downcased_label = space_compressed_label.downcase
+          return super if XML_NAME_START_CHAR !~ downcased_label
+
+          xml_id_start_ready_label = "#{$MATCH}#{$POSTMATCH}"
+          xml_id_ready_label = ""
+          xml_id_start_ready_label.scan(/#{XML_NAME_CHAR}+/) do |xml_id_string|
+            xml_id_ready_label << xml_id_string
+          end
+          meta_char_escape(xml_id_ready_label)
+        end
+      end
+    end
+  end
+end

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -54,3 +54,7 @@ command("/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go", /pod/)
     $1
   end
 end
+
+markup("github/markup/rd", /rd/) do |content|
+  GitHub::Markup::RD.new(content).to_html
+end

--- a/test/markups/README.rd
+++ b/test/markups/README.rd
@@ -1,0 +1,73 @@
+# -*- mode: rd; coding: utf-8; indent-tabs-mode: nil -*-
+= RDtool 0.6.37
+== What is RDtool
+
+RD is Ruby's POD. RDtool is formatter for RD.
+
+== What is Changed
+
+See HISTORY.
+
+== How to Install
+
+ (1)((%su%)) if you install into public directories.
+ (2)((%ruby setup.rb%))
+ (3)If you want to use , utils/rd-mode.el, install it ((*by hand*)).
+
+== How to use
+
+Simply,
+  % rd2 rdfile.rd > outputfile
+
+If you want to indicate format-library, do
+  % rd2 -r library rdfile.rd > outputfile
+
+Use ((% rd2 --help %)) for more options.
+
+For options depend on format-library, enter ((%--help%)) after
+the indication of format-library. For example,
+
+  % rd2 -r rd/rd2html-lib.rb --help
+
+rd2 load "${HOME}/.rd2rc" when it runs.
+
+== How to write RD?
+
+Please read doc/rd-draft.rd.
+
+== About bug report
+
+If you find a bug in RDtool, please add new
+((<"issues at gihtub"|URL:https://github.com/uwabami/rdtool/issues>)),
+or E-mail me ((<URL:mailto:uwabami@gfd-dennou.org>)).
+
+== Copyright and License
+
+You can use/re-distribute/change RDtool under Ruby's License or GPL-2+.
+see LICNESE.txt and COPYING.txt. This distribution of RDtool include
+files that are copyrighted by somebody else, and these files can be
+re-distributed under those own license.
+
+These files include the condition of those licenses in themselves. The
+license information for every files is as follows.
+
+ Files: */
+   * Copyright: 2004 MoonWolf <moonwolf@moonwolf.com>
+                2011-2012 Youhei SASAKI <uwabami@gfd-dennou.org>
+   * License: Ruby's License or GPL-2+
+ Files: lib/rd/rd2man-lib.rb
+   * Copyright: 2000  WATANABE Hirofumi
+                2012 Youhei SASAKI <uwabami@gfd-dennou.org>
+   * License: Ruby's License or GPL-2+
+ Files: lib/rd/{head-filter,rd2html-ext-lib,rd2html-ext-opt}.rb
+   * Copyright: 2003 Rubikitch
+   * License: Ruby's License or GPL-2+
+ Files: bin/rdswap
+   * Copyright: 1999 C.Hintze
+   * License: Ruby's License or GPL-2+
+ Files: setup.rb
+   * Copyright: 2000-2006 Minero Aoki
+   * License: LGPL-2.1
+ Files: utils/rd-mode.el
+   * Copyright: 1999 Koji Arai, Toshiro Kuwabara.
+   * License: GPL-2+

--- a/test/markups/README.rd.html
+++ b/test/markups/README.rd.html
@@ -1,0 +1,54 @@
+<h1><a name="rdtool-0.6.37" id="rdtool-0.6.37">RDtool 0.6.37</a></h1>
+<h2><a name="what-is-rdtool" id="what-is-rdtool">What is RDtool</a></h2>
+<p>RD is Ruby's POD. RDtool is formatter for RD.</p>
+<h2><a name="what-is-changed" id="what-is-changed">What is Changed</a></h2>
+<p>See HISTORY.</p>
+<h2><a name="how-to-install" id="how-to-install">How to Install</a></h2>
+<ol>
+<li><kbd>su</kbd> if you install into public directories.</li>
+<li><kbd>ruby setup.rb</kbd></li>
+<li>If you want to use , utils/rd-mode.el, install it <em>by hand</em>.</li>
+</ol>
+<h2><a name="how-to-use" id="how-to-use">How to use</a></h2>
+<p>Simply,</p>
+<pre>% rd2 rdfile.rd &gt; outputfile</pre>
+<p>If you want to indicate format-library, do</p>
+<pre>% rd2 -r library rdfile.rd &gt; outputfile</pre>
+<p>Use <kbd> rd2 --help </kbd> for more options.</p>
+<p>For options depend on format-library, enter <kbd>--help</kbd> after
+the indication of format-library. For example,</p>
+<pre>% rd2 -r rd/rd2html-lib.rb --help</pre>
+<p>rd2 load "${HOME}/.rd2rc" when it runs.</p>
+<h2><a name="how-to-write-rd?" id="how-to-write-rd?">How to write RD?</a></h2>
+<p>Please read doc/rd-draft.rd.</p>
+<h2><a name="about-bug-report" id="about-bug-report">About bug report</a></h2>
+<p>If you find a bug in RDtool, please add new
+<a href="https://github.com/uwabami/rdtool/issues">issues at gihtub</a>,
+or E-mail me <a href="mailto:uwabami@gfd-dennou.org">&lt;URL:mailto:uwabami@gfd-dennou.org&gt;</a>.</p>
+<h2><a name="copyright-and-license" id="copyright-and-license">Copyright and License</a></h2>
+<p>You can use/re-distribute/change RDtool under Ruby's License or GPL-2+.
+see LICNESE.txt and COPYING.txt. This distribution of RDtool include
+files that are copyrighted by somebody else, and these files can be
+re-distributed under those own license.</p>
+<p>These files include the condition of those licenses in themselves. The
+license information for every files is as follows.</p>
+<pre>Files: */
+  * Copyright: 2004 MoonWolf &lt;moonwolf@moonwolf.com&gt;
+               2011-2012 Youhei SASAKI &lt;uwabami@gfd-dennou.org&gt;
+  * License: Ruby's License or GPL-2+
+Files: lib/rd/rd2man-lib.rb
+  * Copyright: 2000  WATANABE Hirofumi
+               2012 Youhei SASAKI &lt;uwabami@gfd-dennou.org&gt;
+  * License: Ruby's License or GPL-2+
+Files: lib/rd/{head-filter,rd2html-ext-lib,rd2html-ext-opt}.rb
+  * Copyright: 2003 Rubikitch
+  * License: Ruby's License or GPL-2+
+Files: bin/rdswap
+  * Copyright: 1999 C.Hintze
+  * License: Ruby's License or GPL-2+
+Files: setup.rb
+  * Copyright: 2000-2006 Minero Aoki
+  * License: LGPL-2.1
+Files: utils/rd-mode.el
+  * Copyright: 1999 Koji Arai, Toshiro Kuwabara.
+  * License: GPL-2+</pre>

--- a/test/markups/README_no_begin_end.rd
+++ b/test/markups/README_no_begin_end.rd
@@ -1,0 +1,76 @@
+# -*- mode: rd; coding: utf-8; indent-tabs-mode: nil -*-
+=begin
+= RDtool 0.6.37
+== What is RDtool
+
+RD is Ruby's POD. RDtool is formatter for RD.
+
+== What is Changed
+
+See HISTORY.
+
+== How to Install
+
+ (1)((%su%)) if you install into public directories.
+ (2)((%ruby setup.rb%))
+ (3)If you want to use , utils/rd-mode.el, install it ((*by hand*)).
+
+== How to use
+
+Simply,
+  % rd2 rdfile.rd > outputfile
+
+If you want to indicate format-library, do
+  % rd2 -r library rdfile.rd > outputfile
+
+Use ((% rd2 --help %)) for more options.
+
+For options depend on format-library, enter ((%--help%)) after
+the indication of format-library. For example,
+
+  % rd2 -r rd/rd2html-lib.rb --help
+
+rd2 load "${HOME}/.rd2rc" when it runs.
+
+== How to write RD?
+
+Please read doc/rd-draft.rd.
+
+== About bug report
+
+If you find a bug in RDtool, please add new
+((<"issues at gihtub"|URL:https://github.com/uwabami/rdtool/issues>)),
+or E-mail me ((<URL:mailto:uwabami@gfd-dennou.org>)).
+
+== Copyright and License
+
+You can use/re-distribute/change RDtool under Ruby's License or GPL-2+.
+see LICNESE.txt and COPYING.txt. This distribution of RDtool include
+files that are copyrighted by somebody else, and these files can be
+re-distributed under those own license.
+
+These files include the condition of those licenses in themselves. The
+license information for every files is as follows.
+
+ Files: */
+   * Copyright: 2004 MoonWolf <moonwolf@moonwolf.com>
+                2011-2012 Youhei SASAKI <uwabami@gfd-dennou.org>
+   * License: Ruby's License or GPL-2+
+ Files: lib/rd/rd2man-lib.rb
+   * Copyright: 2000  WATANABE Hirofumi
+                2012 Youhei SASAKI <uwabami@gfd-dennou.org>
+   * License: Ruby's License or GPL-2+
+ Files: lib/rd/{head-filter,rd2html-ext-lib,rd2html-ext-opt}.rb
+   * Copyright: 2003 Rubikitch
+   * License: Ruby's License or GPL-2+
+ Files: bin/rdswap
+   * Copyright: 1999 C.Hintze
+   * License: Ruby's License or GPL-2+
+ Files: setup.rb
+   * Copyright: 2000-2006 Minero Aoki
+   * License: LGPL-2.1
+ Files: utils/rd-mode.el
+   * Copyright: 1999 Koji Arai, Toshiro Kuwabara.
+   * License: GPL-2+
+
+=end

--- a/test/markups/README_no_begin_end.rd.html
+++ b/test/markups/README_no_begin_end.rd.html
@@ -1,0 +1,54 @@
+<h1><a name="rdtool-0.6.37" id="rdtool-0.6.37">RDtool 0.6.37</a></h1>
+<h2><a name="what-is-rdtool" id="what-is-rdtool">What is RDtool</a></h2>
+<p>RD is Ruby's POD. RDtool is formatter for RD.</p>
+<h2><a name="what-is-changed" id="what-is-changed">What is Changed</a></h2>
+<p>See HISTORY.</p>
+<h2><a name="how-to-install" id="how-to-install">How to Install</a></h2>
+<ol>
+<li><kbd>su</kbd> if you install into public directories.</li>
+<li><kbd>ruby setup.rb</kbd></li>
+<li>If you want to use , utils/rd-mode.el, install it <em>by hand</em>.</li>
+</ol>
+<h2><a name="how-to-use" id="how-to-use">How to use</a></h2>
+<p>Simply,</p>
+<pre>% rd2 rdfile.rd &gt; outputfile</pre>
+<p>If you want to indicate format-library, do</p>
+<pre>% rd2 -r library rdfile.rd &gt; outputfile</pre>
+<p>Use <kbd> rd2 --help </kbd> for more options.</p>
+<p>For options depend on format-library, enter <kbd>--help</kbd> after
+the indication of format-library. For example,</p>
+<pre>% rd2 -r rd/rd2html-lib.rb --help</pre>
+<p>rd2 load "${HOME}/.rd2rc" when it runs.</p>
+<h2><a name="how-to-write-rd?" id="how-to-write-rd?">How to write RD?</a></h2>
+<p>Please read doc/rd-draft.rd.</p>
+<h2><a name="about-bug-report" id="about-bug-report">About bug report</a></h2>
+<p>If you find a bug in RDtool, please add new
+<a href="https://github.com/uwabami/rdtool/issues">issues at gihtub</a>,
+or E-mail me <a href="mailto:uwabami@gfd-dennou.org">&lt;URL:mailto:uwabami@gfd-dennou.org&gt;</a>.</p>
+<h2><a name="copyright-and-license" id="copyright-and-license">Copyright and License</a></h2>
+<p>You can use/re-distribute/change RDtool under Ruby's License or GPL-2+.
+see LICNESE.txt and COPYING.txt. This distribution of RDtool include
+files that are copyrighted by somebody else, and these files can be
+re-distributed under those own license.</p>
+<p>These files include the condition of those licenses in themselves. The
+license information for every files is as follows.</p>
+<pre>Files: */
+  * Copyright: 2004 MoonWolf &lt;moonwolf@moonwolf.com&gt;
+               2011-2012 Youhei SASAKI &lt;uwabami@gfd-dennou.org&gt;
+  * License: Ruby's License or GPL-2+
+Files: lib/rd/rd2man-lib.rb
+  * Copyright: 2000  WATANABE Hirofumi
+               2012 Youhei SASAKI &lt;uwabami@gfd-dennou.org&gt;
+  * License: Ruby's License or GPL-2+
+Files: lib/rd/{head-filter,rd2html-ext-lib,rd2html-ext-opt}.rb
+  * Copyright: 2003 Rubikitch
+  * License: Ruby's License or GPL-2+
+Files: bin/rdswap
+  * Copyright: 1999 C.Hintze
+  * License: Ruby's License or GPL-2+
+Files: setup.rb
+  * Copyright: 2000-2006 Minero Aoki
+  * License: LGPL-2.1
+Files: utils/rd-mode.el
+  * Copyright: 1999 Koji Arai, Toshiro Kuwabara.
+  * License: GPL-2+</pre>


### PR DESCRIPTION
About RD cited from http://uwabami.github.com/rdtool/:

```
RD is Ruby's POD. RDtool is formatter for RD.

RD is multipurpose documentation format created for documentating
Ruby and output of Ruby world. You can embed RD into Ruby
script. And RD have neat syntax which help you to read document in
Ruby script. On the other hand, RD have a feature for class
reference.
```
