### PR TITLE
increase the length of options in the option list

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -25,6 +25,7 @@ SETTINGS = {
     'raw_enabled': False,
     'strip_comments': True,
     'doctitle_xform': False,
+    'option_limit': 28,
     'report_level': 5,
     'syntax_highlight' : 'none',
     'math_output' : 'latex'


### PR DESCRIPTION
The default maximum length of option in an option list fo restructured text is
14. This heuristic may have been good a few years back. By now we all have huge
displays, so doubling it should be fine. This should imporve the way option
lists are displayed by the browser since options and their descriptions will
be split into seperate lines less often.
