### PR TITLE
Render only content by Asciidoctor

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -45,7 +45,7 @@ markup(:literati, /lhs/) do |content|
 end
 
 markup(:asciidoctor, /asc|adoc|asciidoc/) do |content|
-  Asciidoctor::Document.new(content).render
+  Asciidoctor::Document.new(content, :header_footer => false).render
 end
 
 command(:rest2html, /re?st(\.txt)?/)

--- a/test/markups/README.asciidoc.html
+++ b/test/markups/README.asciidoc.html
@@ -1,12 +1,15 @@
-<div class="ulist"><ul>
-<li>
-<p>
-One
-</p>
-</li>
-<li>
-<p>
-Two
-</p>
-</li>
-</ul></div>
+      <div class='ulist'>
+        <ul>
+        
+          <li>
+            <p>One</p>
+            
+          </li>
+        
+          <li>
+            <p>Two</p>
+            
+          </li>
+        
+        </ul>
+      </div>


### PR DESCRIPTION
From 320e6e081efcf27c087888de6d9e6eec6cf0e80, asciidoc is rendered by  erebor/asciidoctor.

`Asciidoctor::Document.new(content).render` include header and footer document.
This pull-req fix it and adjust test.
