### PR TITLE
Remove copyright in public domain rest2html

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -3,7 +3,7 @@
 """A small wrapper file for parsing ReST files at GitHub."""
 
 __author__ = "Jannis Leidel"
-__copyright__ = "Copyright (C) 2008 Jannis Leidel"
+__copyright__ = "Public Domain"
 __license__ = "Public Domain"
 __version__ = "0.1"
 


### PR DESCRIPTION
I'm no lawyer, but if the license is "Public Domain" I'm reasonably sure that equals no-copyright in most countries. Having a copyright statement, and saying it's public domain are incompatible.

Not a huge deal, but worth fixing.
