### PR TITLE
Add .ad as asciidoc extension

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -44,7 +44,7 @@ markup(:literati, /lhs/) do |content|
   Literati.render(content)
 end
 
-markup(:asciidoctor, /asc|adoc|asciidoc/) do |content|
+markup(:asciidoctor, /ad|asc|adoc|asciidoc/) do |content|
   Asciidoctor::Document.new(content).render
 end
 


### PR DESCRIPTION
It's only logical that .ad be an extension for AsciiDoc to parallel .md for Markdown. I think this will help adoption (and save a few keystrokes). We're trend setting :)
