### PR TITLE
rst: use align-attribute for images

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -40,6 +40,26 @@ class GitHubHTMLTranslator(HTMLTranslator):
         else:
             self.body.append(self.starttag(node, 'pre'))
 
+    def visit_image(self, node):
+        """Custom visit_image for using the HTML align attribute for
+        image alignment, since css-classes will be stripped.
+        """
+        HTMLTranslator.visit_image(self, node)
+        if self.body[-1].startswith('<img'):
+            align = None
+
+            if 'align' in node:
+                # image with alignment
+                align = node['align']
+
+            elif node.parent.tagname == 'figure' and 'align' in node.parent:
+                # figure with alignment
+                align = node.parent['align']
+
+            if align:
+                self.body[-1] = self.body[-1].replace(
+                    ' />', ' align="%s" />' % align)
+
 def main():
     """
     Parses the given ReST file or the redirected string input and returns the

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -11,3 +11,6 @@ Header 2
 2. More ``code``, hooray
 
 3. Somé UTF-8°
+
+.. image:: foo.png
+   :align: right

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -9,6 +9,7 @@
 <li>More <tt class="docutils literal">code</tt>, hooray</li>
 <li>Somé UTF-8°</li>
 </ol>
+<img alt="foo.png" class="align-right" src="foo.png" align="right" />
 </div>
 </div>
 </div>


### PR DESCRIPTION
At the moment it is impossible to change the image alignment when using restructured text on github (see #163).

The docutils `HTMLTranslator` is using css-classes for alignment, which are stripped by github later.
Using the HTML align attribute would be more appropriate, I think.

This pull-request adds the alignment value from restructured text in `figure` and `image` statements as `align` value to the HTML `img` tag.

I'm not sure whether this is the way it should be for github, but I think it should work well.
