### PR TITLE
Update dependency instructions for .asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you wish to run the library.
 * [.creole](http://wikicreole.org/) -- `gem install creole`
 * [.mediawiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth`
 * [.rst](http://docutils.sourceforge.net/rst.html) -- `easy_install docutils`
-* [.asciidoc](http://www.methods.co.nz/asciidoc/) -- `brew install asciidoc`
+* [.asciidoc](http://www.methods.co.nz/asciidoc/) -- `gem install asciidoctor`
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.
 


### PR DESCRIPTION
Change dependency for .asciidoc from the asciidoc application to the asciidoctor gem.
