### PR TITLE
Make links in README relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,6 @@ Contributing
 6. Enjoy a refreshing Diet Coke and wait
 
 
-[r2h]: http://github.com/github/markup/tree/master/lib/github/commands/rest2html
-[r2hc]: http://github.com/github/markup/tree/master/lib/github/markups.rb#L13
+[r2h]: lib/github/commands/rest2html
+[r2hc]: lib/github/markups.rb#L51
 [1]: http://github.com/github/markup/pulls


### PR DESCRIPTION
This also updates the line number to point at the correct place to show off how `rest2html` use is defined. That's a little shaky, though, and there's not much that can be done about that unless you want to link to a specific commit.

Line 13, seriously.
