### PR TITLE
Fix Rdoc render with ruby 2.0

### DIFF
--- a/lib/github/markup/rdoc.rb
+++ b/lib/github/markup/rdoc.rb
@@ -9,7 +9,11 @@ module GitHub
       end
 
       def to_html
-        h = ::RDoc::Markup::ToHtml.new
+        if Gem::Version.new(::RDoc::VERSION) < Gem::Version.new('4.0.0')
+          h = ::RDoc::Markup::ToHtml.new
+        else
+          h = ::RDoc::Markup::ToHtml.new(::RDoc::Options.new)
+        end
         h.convert(@content)
       end
     end


### PR DESCRIPTION
Avoid errors when rendering with ruby > 1.9
ie:

```
 ArgumentError:
   wrong number of arguments (0 for 1..2)
 # (eval):28:in `block in <module:Markup>'
```
