### PR TITLE
remove rst table border

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -40,6 +40,14 @@ class GitHubHTMLTranslator(HTMLTranslator):
         else:
             self.body.append(self.starttag(node, 'pre'))
 
+    def visit_table(self, node):
+        classes = ' '.join(['docutils', self.settings.table_style]).strip()
+        self.body.append(
+                self.starttag(node, 'table', CLASS=classes))
+
+    def depart_table(self, node):
+        self.body.append('</table>\n')
+
 def main():
     """
     Parses the given ReST file or the redirected string input and returns the


### PR DESCRIPTION
## Description

Python's docutils generates a table with `border=1` by default (See # 1). 

This looks out of place with gh's look and feel, see 

Before:
![_111](https://f.cloud.github.com/assets/1067951/1234970/5f345132-2994-11e3-8b25-ce117a150b13.png)

After:
![_112](https://f.cloud.github.com/assets/1067951/1234976/7d164520-2994-11e3-87db-9706c8d4e47a.png)

Fixes the hard-coded `border=1` in the `html4css1` parser.

Link # 1: http://sourceforge.net/p/docutils/code/7661/tree/trunk/docutils/docutils/writers/html4css1/__init__.py#l1556

Scope:  github `rest2html` parser.   [docutils.writer.html4css1](https://github.com/github/markup/blob/master/lib/github/commands/rest2html)    
