### PR TITLE
Update docs and bootstrap for asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.creole](http://wikicreole.org/) -- `gem install creole`
 * [.mediawiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth`
 * [.rst](http://docutils.sourceforge.net/rst.html) -- `easy_install docutils`
-* [.asciidoc, .adoc, .asc](http://www.methods.co.nz/asciidoc/) -- `brew install asciidoc`
+* [.asciidoc, .adoc, .asc](http://www.methods.co.nz/asciidoc/) -- `gem install asciidoctor`
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,4 +6,3 @@ cd $(dirname "$0")/..
 
 bundle install
 easy_install docutils
-brew install asciidoc


### PR DESCRIPTION
Don't need to install asciidoc with brew anymore.
