### PR TITLE
Switch to Pod::Simple::XHTML.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 before_install:
-  - sudo pip install docutils
+  - sudo pip install docutils cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get install perl-doc
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
-  - "/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: test/markups/README.pod"
+  - "/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: -T test/markups/README.pod"
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ before_install:
   - sudo apt-get install perl-doc
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
-  - "/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: -T test/markups/README.pod"
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-before_install: sudo pip install docutils
+before_install:
+  - sudo pip install docutils
+  - sudo cpanm --installdeps --notest Pod::Simple
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ before_install:
   - sudo apt-get install perl-doc
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
-  - /usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: test/markups/README.pod
+  - "/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: test/markups/README.pod"
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 before_install:
-  - sudo pip install docutils cpanminus
+  - sudo pip install docutils
+  - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
 rvm:
   - 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 before_install:
   - sudo pip install docutils
+  - sudo apt-get install perl-doc
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_install:
   - sudo apt-get install perl-doc
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
+  - /usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: test/markups/README.pod
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 before_install:
   - sudo pip install docutils
-  - sudo apt-get install perl-doc
-  - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
-  - sudo cpanm --installdeps --notest Pod::Simple
 rvm:
   - 1.9.3
   - 2.0.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.mediawiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth`
 * [.rst](http://docutils.sourceforge.net/rst.html) -- `easy_install docutils`
 * [.asciidoc, .adoc, .asc](http://asciidoc.org/) -- `gem install asciidoctor` (http://asciidoctor.org)
-* [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`
+* [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::XHTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.
 
 HTML sanitization

--- a/lib/github/commands/pod2html
+++ b/lib/github/commands/pod2html
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl -w
+
+use strict;
+use Pod::Simple::XHTML 3.11;
+
+my $p = Pod::Simple::XHTML->new;
+$p->html_header('');
+$p->html_footer('');
+$p->strip_verbatim_indent(sub {
+    my $lines = shift;
+    (my $indent = $lines->[0]) =~ s/\S.*//;
+    return $indent;
+});
+$p->parse_from_file(shift);

--- a/lib/github/markup/command_implementation.rb
+++ b/lib/github/markup/command_implementation.rb
@@ -43,10 +43,10 @@ module GitHub
           out = stdout.read
         end
         out.gsub("\r", '')
-      # rescue Errno::EPIPE
-      #   ""
-      # rescue Errno::ENOENT
-      #   ""
+      rescue Errno::EPIPE
+        ""
+      rescue Errno::ENOENT
+        ""
       end
     end
   end

--- a/lib/github/markup/command_implementation.rb
+++ b/lib/github/markup/command_implementation.rb
@@ -6,6 +6,7 @@ end
 
 require "github/markup/implementation"
 
+
 module GitHub
   module Markup
     class CommandImplementation < Implementation

--- a/lib/github/markup/command_implementation.rb
+++ b/lib/github/markup/command_implementation.rb
@@ -42,10 +42,10 @@ module GitHub
           out = stdout.read
         end
         out.gsub("\r", '')
-      rescue Errno::EPIPE
-        ""
-      rescue Errno::ENOENT
-        ""
+      # rescue Errno::EPIPE
+      #   ""
+      # rescue Errno::ENOENT
+      #   ""
       end
     end
   end

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -32,5 +32,5 @@ end
 
 command(:rest2html, /re?st(\.txt)?/)
 
-command("/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: -T", /pod/)
+command(:pod2html, /pod/)
 

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -32,13 +32,5 @@ end
 
 command(:rest2html, /re?st(\.txt)?/)
 
-# pod2html is nice enough to generate a full-on HTML document for us,
-# so we return the favor by ripping out the good parts.
-#
-# Any block passed to `command` will be handed the command's STDOUT for
-# post processing.
-command("/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go", /pod/) do |rendered|
-  if rendered =~ /<!-- start doc -->\s*(.+)\s*<!-- end doc -->/mi
-    $1
-  end
-end
+command("/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer:", /pod/)
+

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -32,5 +32,5 @@ end
 
 command(:rest2html, /re?st(\.txt)?/)
 
-command("/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer:", /pod/)
+command("/usr/bin/env perldoc -MPod::Simple::XHTML -w html_header: -w html_footer: -T", /pod/)
 

--- a/test/markups/README.pod
+++ b/test/markups/README.pod
@@ -12,7 +12,7 @@ Primary goals are:
 
 =over 4
 
-=item* Create a working compiler that understands the majority of the
+=item * Create a working compiler that understands the majority of the
 MATLAB/Octave programming language.
 
 =back
@@ -23,14 +23,14 @@ This project is broken into three primary components:
 
 =over 4
 
-=item* The first is the parser, located in the C<src/parser/> directory. The
+=item * The first is the parser, located in the C<src/parser/> directory. The
 parser proper is composed of three source files, F<grammar.pg> which is a
 Perl6Grammar file, and F<actions.pm> which is the associated actions file
 written in NQP, and F<grammar-oper.pm> which is the operator precidence parser.
 In addition, several helper functions used by the parser are located in
 C<src/internals>.
 
-=item* The second component is the library of builtin functions in the
+=item * The second component is the library of builtin functions in the
 C<src/builtins/> directory. These functions are, currently, written primarily in
 PIR. Function names prefixed with an underscore are "private" functions for use
 with the parser. Other functions should have names which are the same as names
@@ -38,7 +38,7 @@ for regular MATLAB or Octave functions, since they will be available to the
 HLL. These are also separated into different namespaces depending on visibility
 and utility.
 
-=item* A number of library functions are written in M, or mostly M with some
+=item * A number of library functions are written in M, or mostly M with some
 inline PIR code in C<toolbox/>.
 
 =back

--- a/test/markups/README.pod.html
+++ b/test/markups/README.pod.html
@@ -10,8 +10,9 @@
 
 <ul>
 
-<p>=item* Create a working compiler that understands the majority of the MATLAB/Octave programming language.</p>
+<li><p>Create a working compiler that understands the majority of the MATLAB/Octave programming language.</p>
 
+</li>
 </ul>
 
 <h2 id="IMPLEMENTATION">IMPLEMENTATION</h2>
@@ -20,12 +21,15 @@
 
 <ul>
 
-<p>=item* The first is the parser, located in the <code>src/parser/</code> directory. The parser proper is composed of three source files, <i>grammar.pg</i> which is a Perl6Grammar file, and <i>actions.pm</i> which is the associated actions file written in NQP, and <i>grammar-oper.pm</i> which is the operator precidence parser. In addition, several helper functions used by the parser are located in <code>src/internals</code>.</p>
+<li><p>The first is the parser, located in the <code>src/parser/</code> directory. The parser proper is composed of three source files, <i>grammar.pg</i> which is a Perl6Grammar file, and <i>actions.pm</i> which is the associated actions file written in NQP, and <i>grammar-oper.pm</i> which is the operator precidence parser. In addition, several helper functions used by the parser are located in <code>src/internals</code>.</p>
 
-<p>=item* The second component is the library of builtin functions in the <code>src/builtins/</code> directory. These functions are, currently, written primarily in PIR. Function names prefixed with an underscore are &quot;private&quot; functions for use with the parser. Other functions should have names which are the same as names for regular MATLAB or Octave functions, since they will be available to the HLL. These are also separated into different namespaces depending on visibility and utility.</p>
+</li>
+<li><p>The second component is the library of builtin functions in the <code>src/builtins/</code> directory. These functions are, currently, written primarily in PIR. Function names prefixed with an underscore are &quot;private&quot; functions for use with the parser. Other functions should have names which are the same as names for regular MATLAB or Octave functions, since they will be available to the HLL. These are also separated into different namespaces depending on visibility and utility.</p>
 
-<p>=item* A number of library functions are written in M, or mostly M with some inline PIR code in <code>toolbox/</code>.</p>
+</li>
+<li><p>A number of library functions are written in M, or mostly M with some inline PIR code in <code>toolbox/</code>.</p>
 
+</li>
 </ul>
 
 <h2 id="DEPENDENCIES">DEPENDENCIES</h2>

--- a/test/markups/README.pod.html
+++ b/test/markups/README.pod.html
@@ -40,10 +40,10 @@
 
 <p>To get a proper version of Parrot to build Matrixy, you will need to check out and build Parrot from source:</p>
 
-<pre><code>    svn co http://svn.parrot.org/parrot/trunk parrot
-    cd parrot
-    perl Configure.pl
-    make &amp;&amp; make test &amp;&amp; make install-dev</code></pre>
+<pre><code>svn co http://svn.parrot.org/parrot/trunk parrot
+cd parrot
+perl Configure.pl
+make &amp;&amp; make test &amp;&amp; make install-dev</code></pre>
 
 <h3 id="Parrot-Linear-Algebra">Parrot-Linear-Algebra</h3>
 
@@ -53,14 +53,14 @@
 
 <p>Once all dependencies are in place, you can build Matrixy using this sequence of commands:</p>
 
-<pre><code>    perl Configure.pl
-    nmake test</code></pre>
+<pre><code>perl Configure.pl
+nmake test</code></pre>
 
 <h2 id="TODO">TODO</h2>
 
-<pre><code>    * Parser
-    * Standard Builtins
-    * Test against Octave Test Suite.</code></pre>
+<pre><code>* Parser
+* Standard Builtins
+* Test against Octave Test Suite.</code></pre>
 
 <h2 id="BUGS">BUGS</h2>
 

--- a/test/markups/README.pod.html
+++ b/test/markups/README.pod.html
@@ -1,106 +1,68 @@
-<a name='___top' class='dummyTopAnchor' ></a>
+<h1 id="Matrixy">Matrixy</h1>
 
-<h1><a class='u' href='#___top' title='click to go to top of document'
-name="Matrixy"
->Matrixy</a></h1>
+<h2 id="INTRODUCTION">INTRODUCTION</h2>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="INTRODUCTION"
->INTRODUCTION</a></h2>
+<p>This is a port of the MATLAB/Octave programming language to Parrot. See the ROADMAP file for more information on the status of this project, and what else needs to be done.</p>
 
-<p>This is a port of the MATLAB/Octave programming language to Parrot.
-See the ROADMAP file for more information on the status of this project,
-and what else needs to be done.</p>
-
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="ABOUT"
->ABOUT</a></h2>
+<h2 id="ABOUT">ABOUT</h2>
 
 <p>Primary goals are:</p>
 
-<blockquote>
-<p>=item* Create a working compiler that understands the majority of the MATLAB/Octave programming language.</p>
-</blockquote>
+<ul>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="IMPLEMENTATION"
->IMPLEMENTATION</a></h2>
+<p>=item* Create a working compiler that understands the majority of the MATLAB/Octave programming language.</p>
+
+</ul>
+
+<h2 id="IMPLEMENTATION">IMPLEMENTATION</h2>
 
 <p>This project is broken into three primary components:</p>
 
-<blockquote>
-<p>=item* The first is the parser,
-located in the <code>src/parser/</code> directory.
-The parser proper is composed of three source files,
-<em>grammar.pg</em> which is a Perl6Grammar file,
-and <em>actions.pm</em> which is the associated actions file written in NQP,
-and <em>grammar-oper.pm</em> which is the operator precidence parser.
-In addition,
-several helper functions used by the parser are located in <code>src/internals</code>.</p>
+<ul>
 
-<p>=item* The second component is the library of builtin functions in the <code>src/builtins/</code> directory.
-These functions are,
-currently,
-written primarily in PIR.
-Function names prefixed with an underscore are &#34;private&#34; functions for use with the parser.
-Other functions should have names which are the same as names for regular MATLAB or Octave functions,
-since they will be available to the HLL.
-These are also separated into different namespaces depending on visibility and utility.</p>
+<p>=item* The first is the parser, located in the <code>src/parser/</code> directory. The parser proper is composed of three source files, <i>grammar.pg</i> which is a Perl6Grammar file, and <i>actions.pm</i> which is the associated actions file written in NQP, and <i>grammar-oper.pm</i> which is the operator precidence parser. In addition, several helper functions used by the parser are located in <code>src/internals</code>.</p>
 
-<p>=item* A number of library functions are written in M,
-or mostly M with some inline PIR code in <code>toolbox/</code>.</p>
-</blockquote>
+<p>=item* The second component is the library of builtin functions in the <code>src/builtins/</code> directory. These functions are, currently, written primarily in PIR. Function names prefixed with an underscore are &quot;private&quot; functions for use with the parser. Other functions should have names which are the same as names for regular MATLAB or Octave functions, since they will be available to the HLL. These are also separated into different namespaces depending on visibility and utility.</p>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="DEPENDENCIES"
->DEPENDENCIES</a></h2>
+<p>=item* A number of library functions are written in M, or mostly M with some inline PIR code in <code>toolbox/</code>.</p>
+
+</ul>
+
+<h2 id="DEPENDENCIES">DEPENDENCIES</h2>
 
 <p>Matrixy depends on these dependencies:</p>
 
-<h3><a class='u' href='#___top' title='click to go to top of document'
-name="Parrot"
->Parrot</a></h3>
+<h3 id="Parrot">Parrot</h3>
 
-<p>To get a proper version of Parrot to build Matrixy,
-you will need to check out and build Parrot from source:</p>
+<p>To get a proper version of Parrot to build Matrixy, you will need to check out and build Parrot from source:</p>
 
-<pre>    svn co http://svn.parrot.org/parrot/trunk parrot
+<pre><code>    svn co http://svn.parrot.org/parrot/trunk parrot
     cd parrot
     perl Configure.pl
-    make &#38;&#38; make test &#38;&#38; make install-dev</pre>
+    make &amp;&amp; make test &amp;&amp; make install-dev</code></pre>
 
-<h3><a class='u' href='#___top' title='click to go to top of document'
-name="Parrot-Linear-Algebra"
->Parrot-Linear-Algebra</a></h3>
+<h3 id="Parrot-Linear-Algebra">Parrot-Linear-Algebra</h3>
 
 <p>The linear algebra package for Parrot is available separately and provides functionality required by Matrixy. This includes matrix data types and matrix manipulation libraries</p>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="BUILDING"
->BUILDING</a></h2>
+<h2 id="BUILDING">BUILDING</h2>
 
 <p>Once all dependencies are in place, you can build Matrixy using this sequence of commands:</p>
 
-<pre>    perl Configure.pl
-    nmake test</pre>
+<pre><code>    perl Configure.pl
+    nmake test</code></pre>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="TODO"
->TODO</a></h2>
+<h2 id="TODO">TODO</h2>
 
-<pre>    * Parser
+<pre><code>    * Parser
     * Standard Builtins
-    * Test against Octave Test Suite.</pre>
+    * Test against Octave Test Suite.</code></pre>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="BUGS"
->BUGS</a></h2>
+<h2 id="BUGS">BUGS</h2>
 
 <p>Lots!</p>
 
-<h2><a class='u' href='#___top' title='click to go to top of document'
-name="CONTACT"
->CONTACT</a></h2>
+<h2 id="CONTACT">CONTACT</h2>
 
 <p>If you need to contact the Matrixy team, go to the project home page at:</p>
 


### PR DESCRIPTION
There are a few reasons for this:
- It's HTML output is _much_ cleaner.
- You can tell it not to emit headers and footers directly.

The only downside is that you need a fairly recent version of Pod::Simple for
it to be there and really solid. I recommend 3.12 or higher, and at least
3.11.
