### PR TITLE
Lock to org-ruby version 0.9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 gem "redcarpet"
 gem "RedCloth"
 gem "rdoc", "~>3.6"
-gem "org-ruby", ">= 0.9.1"
+gem "org-ruby", "= 0.9.1"
 gem "creole", "~>0.3.6"
 gem "wikicloth", "=0.6.0"
 gem "asciidoctor", "= 0.1.4"


### PR DESCRIPTION
Note: There are already two more minor versions with minor fixes, but locking here to keep the changes in the scope of the original PR at #254
