### PR TITLE
Interpret titles and subtitles in rst

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -52,7 +52,9 @@ SETTINGS = {
     'file_insertion_enabled': False,
     'raw_enabled': False,
     'strip_comments': True,
-    'doctitle_xform': False,
+    'doctitle_xform': True,
+    'sectsubtitle_xform': True,
+    'initial_header_level': 2,
     'report_level': 3,
     'syntax_highlight' : 'none',
     'math_output' : 'latex'

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -1,7 +1,12 @@
 Header 1
 ========
+--------
+Subtitle
+--------
 
 Example text.
+
+.. contents:: Table of Contents
 
 Header 2
 --------

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -1,6 +1,13 @@
-<h1>Header 1</h1>
+<h1 class="title">Header 1</h1>
+<h2 class="subtitle" id="subtitle">Subtitle</h2>
 <p>Example text.</p>
-<h2>Header 2</h2>
+<div class="contents topic" id="table-of-contents">
+<p class="topic-title first">Table of Contents</p>
+<ul class="simple">
+<li><a class="reference internal" href="#header-2" id="id1">Header 2</a></li>
+</ul>
+</div>
+<h2><a class="toc-backref" href="#id1">Header 2</a></h2>
 <ol class="arabic simple">
 <li>Blah blah <tt class="docutils literal">code</tt> blah</li>
 <li>More <tt class="docutils literal">code</tt>, hooray</li>
@@ -8,7 +15,7 @@
 </ol>
 <p>The UTF-8 quote character in this table used to cause python to go boom. Now docutils just displays an error inline so the user can fix it. Upgrading to Python 3 will fix this.</p>
 <div class="system-message">
-<p class="system-message-title">System Message: ERROR/3 (<tt class="docutils">&lt;string&gt;</tt>, line 17)</p>
+<p class="system-message-title">System Message: ERROR/3 (<tt class="docutils">&lt;string&gt;</tt>, line 22)</p>
 <p>Error with CSV data in &quot;csv-table&quot; directive:
 &quot;quotechar&quot; must be an 1-character string</p>
 <pre>

--- a/test/markups/README.rst.txt.html
+++ b/test/markups/README.rst.txt.html
@@ -1,4 +1,4 @@
-<h1>Header 1</h1>
+<h1 class="title">Header 1</h1>
 <p>Example text.</p>
 <h2>Header 2</h2>
 <ol class="arabic simple">


### PR DESCRIPTION
This hopes to make subtitles usable without changing the markup and
table-of-contents generation of documents much at all.

This is an attempt to solve https://github.com/github/markup/issues/278

Previously, titles and subtitles[0] would introduce a lot of nesting
in a generated table of contents.  Enable both `doctitle_xform` and
`sectsubtitle_xform` to remove those.

However, merely enabling those will cause the existing top-level,
non-title HTML header sizes to be promoted to `<h1>`, since titles and
subtitles are not considered "sections", changing how the HTML output
looks a rather lot.

That's not how some sampled rsts (without subtitles) on work today:
the title is biggest at `<h1>`, and all other sections are `<h2>` or
below.  So set the `initial_header_level` to `2`, so that the largest
text sections can have is `<h2>`, tied in size for the subtitle.
