### PR TITLE
States that .wiki files are rendered using Mediawiki syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.rdoc](http://rdoc.sourceforge.net/) -- `gem install rdoc -v 3.6.1`
 * [.org](http://orgmode.org/) -- `gem install org-ruby`
 * [.creole](http://wikicreole.org/) -- `gem install creole`
-* [.mediawiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth`
+* [.mediawiki, .wiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth`
 * [.rst](http://docutils.sourceforge.net/rst.html) -- `easy_install docutils`
 * [.asciidoc, .adoc, .asc](http://asciidoc.org/) -- `gem install asciidoctor` (http://asciidoctor.org)
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`


### PR DESCRIPTION
I've discovered today that .wiki files are rendered as HTML, and after some trials-and-errors and a confirmation on stackoverflow, they are rendered using Mediawiki syntax.

This pull request updates the documentation accordingly.
