### PR TITLE
rst2html: Extend the field_name_limit to 50

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -57,7 +57,8 @@ SETTINGS = {
     'initial_header_level': 2,
     'report_level': 5,
     'syntax_highlight' : 'none',
-    'math_output' : 'latex'
+    'math_output' : 'latex',
+    'field_name_limit': 50,
 }
 
 class GitHubHTMLTranslator(HTMLTranslator):

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -46,3 +46,12 @@ Source          https://github.com/tony/pullv
 
 .. image:: https://scan.coverity.com/projects/621/badge.svg
 	:alt: Coverity Scan Build Status
+
+Field list
+----------
+
+:123456789 123456789 123456789 123456789 123456789 1: Uh-oh! This name is too long!
+:123456789 123456789 123456789 123456789 1234567890: this is a long name,
+	but no problem!
+:123456789 12345: this is not so long, but long enough for the default!
+:123456789 1234: this should work even with the default :)

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -5,6 +5,7 @@
 <p class="topic-title first">Table of Contents</p>
 <ul class="simple">
 <li><a class="reference internal" href="#header-2" id="id1">Header 2</a></li>
+<li><a class="reference internal" href="#field-list" id="id2">Field list</a></li>
 </ul>
 </div>
 <h2><a class="toc-backref" href="#id1">Header 2</a></h2>
@@ -40,3 +41,21 @@
 <a class="reference external image-reference" href="https://scan.coverity.com/projects/621"><img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/621/badge.svg">
 </a>
 <img alt="Coverity Scan Build Status" src="https://scan.coverity.com/projects/621/badge.svg">
+<h2><a class="toc-backref" href="#id2">Field list</a></h2>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name" />
+<col class="field-body" />
+<tbody valign="top">
+<tr class="field"><th class="field-name" colspan="2">123456789 123456789 123456789 123456789 123456789 1:</th></tr>
+<tr class="field"><td>&nbsp;</td><td class="field-body">Uh-oh! This name is too long!</td>
+</tr>
+<tr class="field"><th class="field-name">123456789 123456789 123456789 123456789 1234567890:</th><td class="field-body">this is a long name,
+but no problem!</td>
+</tr>
+<tr class="field"><th class="field-name">123456789 12345:</th><td class="field-body">this is not so long, but long enough for the default!</td>
+</tr>
+<tr class="field"><th class="field-name">123456789 1234:</th><td class="field-body">this should work even with the default :)</td>
+</tr>
+</tbody>
+</table>
+


### PR DESCRIPTION
Field lists are rendered weirdly in reST if the field name is longer that 14 characters. In this case the table cell where the field name is gets a `colspan=2`.

For example this:

``` rest
:123456789012345: too long, colspan=2
:12345678901234: OK
```

Gets translated to:

``` html
<table class="docinfo" frame="void" rules="none">
<col class="docinfo-name" />
<col class="docinfo-content" />
<tbody valign="top">
<tr class="field"><th class="docinfo-name"
colspan="2">123456789012345:</th></tr>
<tr class="field"><td>&nbsp;</td><td class="field-body">too long,
colspan=2</td>
</tr>
<tr class="field"><th class="docinfo-name">12345678901234:</th><td
class="field-body">OK</td>
</tr>
</tbody>
</table>
```

Increasing this default value of 14 to something more reasonable, like 50, seems sensible. Even when this is just another arbitrary value, since GitHub have a fixed total width, it seems sensible to not make it
much more longer, since if the field name is too long it will look weird anyway.
