### PR TITLE
Show swallowed errors with notice

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -121,7 +121,10 @@ class GitHubHTMLTranslator(HTMLTranslator):
     # we want to discard most of the <div> fluff that `system_message` gives us: http://bit.ly/1k5wnsb
     # it should be safe to just manipulate the resulting DOM object
     def depart_system_message(self, node):
-      self.body[-6] = self.starttag(node, 'div', CLASS='system-error')
+      atts = {}
+      atts['class'] = 'system-error'
+      atts['data-markup-message'] = 'rst-system-error'
+      self.body[-6] = self.starttag(node, 'div', **atts)
       self.body[-4] = '</div>\n'
 
 

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -14,7 +14,7 @@
 <li>Somé UTF-8°</li>
 </ol>
 <p>The UTF-8 quote character in this table used to cause python to go boom. Now docutils just silently ignores it.</p>
-<div class="system-error">
+<div class="system-error" data-markup-message="rst-system-error">
 Error with CSV data in &quot;csv-table&quot; directive:
 &quot;quotechar&quot; must be an 1-character string</div>
 <pre>


### PR DESCRIPTION
Just some late night hacking. :moon: :sleepy: :computer:  

Right now, we're swallowing errors from RST; see https://github.com/github/markup/pull/271 or https://github.com/github/markup/pull/267.

What we could do instead is keep the logging level low, but, don't bomb, preserve the error message, and show the suspect text inline within a `pre`. Without such changes, faulty RST text just doesn't show up at all. 
it kind of looks like a blunder on GitHub's part, IMHO.

Raw, it'd look something like this:

``` html
<p>The UTF-8 quote character in this table used to cause python to go boom. Now docutils just silently ignores it.</p>
<div class="system-error" data-markup-message="rst-system-error">
Error with CSV data in &quot;csv-table&quot; directive:
&quot;quotechar&quot; must be an 1-character string</div>
<pre>
.. csv-table:: Things that are Awesome (on a scale of 1-11)
        :quote: ”

        Thing,Awesomeness
        Icecream, 7
        Honey Badgers, 10.5
        Nickelback, -2
        Iron Man, 10
        Iron Man 2, 3
        Tabular Data, 5
        Made up ratings, 11

</pre>
```

In real life, it could maybe be something like:

![screen shot 2014-05-28 at 10 19 08 pm](https://cloud.githubusercontent.com/assets/64050/3114317/cb175470-e6f0-11e3-9377-fc98badf8f40.png)

/cc @bkeepers @raganwald who worked around this before
/cc @github/markdown @github/user-content 
