### PR TITLE
Render RMarkdown (.rmd) as Markdown

### DIFF
--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -25,7 +25,7 @@ module GitHub
       }
 
       def initialize
-        super(/md|mkdn?|mdwn|mdown|markdown|litcoffee/)
+        super(/md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee/)
       end
 
       def load

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -35,6 +35,7 @@ message
   def test_knows_what_it_can_and_cannot_render
     assert_equal false, GitHub::Markup.can_render?('README.html')
     assert_equal true, GitHub::Markup.can_render?('README.markdown')
+    assert_equal true, GitHub::Markup.can_render?('README.rmd')
     assert_equal false, GitHub::Markup.can_render?('README.cmd')
     assert_equal true, GitHub::Markup.can_render?('README.litcoffee')
   end

--- a/test/markups/README.rmd
+++ b/test/markups/README.rmd
@@ -1,0 +1,3 @@
+# Title
+* One
+* Two

--- a/test/markups/README.rmd.html
+++ b/test/markups/README.rmd.html
@@ -1,0 +1,6 @@
+<h1>Title</h1>
+
+<ul>
+<li>One</li>
+<li>Two</li>
+</ul>


### PR DESCRIPTION
This PR makes RMarkdown files (`.rmd`) rendered as Markdownl.
If I'm right, this should enable rendering for `.rmd` files in Gist? (It would be better than the current situation where there is no rendering at all.)
