### PR TITLE
Properly escape the filepath to rest2html

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -1,4 +1,5 @@
 require "github/markup/markdown"
+require "shellwords"
 
 markups << GitHub::Markup::Markdown.new
 
@@ -29,7 +30,7 @@ markup(:asciidoctor, /adoc|asc(iidoc)?/) do |content|
   Asciidoctor.render(content, :safe => :secure, :attributes => %w(showtitle idprefix idseparator=- env=github env-github source-highlighter=html-pipeline))
 end
 
-command("python2 -S #{File.dirname(__FILE__)}/commands/rest2html", /re?st(\.txt)?/)
+command("python2 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html", /re?st(\.txt)?/)
 
 # pod2html is nice enough to generate a full-on HTML document for us,
 # so we return the favor by ripping out the good parts.


### PR DESCRIPTION
This PR fixes a bug in `master` that occurs when the filepath to github-markup contains spaces. Currently, the unescaped filepath containing spaces would be passed to CommandImplementation#execute, causing the following error:

```
ludwig:markup dawa$ pwd
/Users/dawa/Test Dir/markup
ludwig:markup dawa$ rake
[...]
GitHub::Markup::CommandError: /usr/local/Cellar/python/2.7.7_2/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python: can't find '__main__' module in '/Users/dawa/Test'
```
