### PR TITLE
Replace the deprecated RedcarpetCompat instance

### DIFF
--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -8,7 +8,7 @@ module GitHub
           GitHub::Markdown.render(content)
         },
         "redcarpet" => proc { |content|
-          RedcarpetCompat.new(content).to_html
+          Redcarpet::Markdown.new(Redcarpet::Render::HTML).render(content)
         },
         "rdiscount" => proc { |content|
           RDiscount.new(content).to_html


### PR DESCRIPTION
As mentioned in #385, this pull request replaces the `RedcarpetCompat` instance with `Redcarpet::Markdown`.
