### PR TITLE
upgrade to Asciidoctor 1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,5 @@ gem "rdoc", "~>3.6"
 gem "org-ruby", "= 0.9.9"
 gem "creole", "~>0.3.6"
 gem "wikicloth", "=0.8.1", :platforms => :ruby
-gem "asciidoctor", "= 0.1.4"
+gem "asciidoctor", "= 1.5.2"
 gem "rake"

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -26,7 +26,8 @@ markup(:wikicloth, /mediawiki|wiki/) do |content|
 end
 
 markup(:asciidoctor, /adoc|asc(iidoc)?/) do |content|
-  Asciidoctor.render(content, :safe => :secure, :attributes => %w(showtitle idprefix idseparator=- env=github env-github source-highlighter=html-pipeline))
+  Asciidoctor::Compliance.unique_id_start_index = 1
+  Asciidoctor.convert(content, :safe => :secure, :attributes => %w(showtitle=@ idprefix idseparator=- env=github env-github source-highlighter=html-pipeline))
 end
 
 command(

--- a/test/markups/README.asciidoc
+++ b/test/markups/README.asciidoc
@@ -5,10 +5,19 @@
 * One
 * Two
 
-== Second Section
+Refer to <<another-section>> or <<another-section-1>>.
+
+== Another Section
 
 NOTE: Here is some source code.
 
 ```ruby
 puts "Hello, World!"
 ```
+
+* [ ] todo
+* [x] done
+
+== Another Section
+
+content

--- a/test/markups/README.asciidoc.html
+++ b/test/markups/README.asciidoc.html
@@ -12,10 +12,13 @@
 </li>
 </ul>
 </div>
+<div>
+<p>Refer to <a href="#another-section">Another Section</a> or <a href="#another-section-1">Another Section</a>.</p>
+</div>
 </div>
 </div>
 <div>
-<h2>Second Section</h2>
+<h2>Another Section</h2>
 <div>
 <div>
 <table>
@@ -33,6 +36,24 @@ Here is some source code.
 <div>
 <pre lang="ruby"><code>puts "Hello, World!"</code></pre>
 </div>
+</div>
+<div>
+<ul>
+<li>
+<p>❏ todo</p>
+</li>
+<li>
+<p>✓ done</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div>
+<h2>Another Section</h2>
+<div>
+<div>
+<p>content</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Refer to the release notes since 0.1.4 for details:

* http://asciidoctor.org/news/2014/08/12/asciidoctor-1-5-0-released/
* https://github.com/asciidoctor/asciidoctor/releases/tag/v1.5.1
* https://github.com/asciidoctor/asciidoctor/releases/tag/v1.5.2

As always, there are performance improvements for migrating from 0.1.4 to 1.5.2 that will improve GitHub services.

Most of the changes pertain to either the extension mechanism or other features that are not enabled in the GitHub environment. The only major difference that affects GitHub users are the changes to the AsciiDoc syntax. The changes are described in detail on the following migration page: http://asciidoctor.org/docs/migration/.

Users can easily restore "legacy" AsciiDoc syntax parsing by setting the `compat-mode` attribute as described in the migration document. I've decided not to enable `compat-mode` by default to encourage adoption of the more consistent syntax (after all, we changed it for good reason).

If you have any questions about the upgrade, don't hesitate to contact me (just mentioning my username will do the trick).

I do still want to try to improve the rendering of AsciiDoc documents on GitHub, but I don't want to couple that improvement with an upgrade to the latest and greatest Asciidoctor processor.