### PR TITLE
Need dev dependencies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ rvm:
   - 2.1.1
 notifications:
   email: false
-bundler_args: --without development


### PR DESCRIPTION
2156565106b6fcdab0bf0b2272439dbf52aff1ef moved minitest to a development dependency, but apparently we were running travis builds without dev dependencies. This never caused issues before because all other "development" dependencies are just listed in the `Gemfile`, which isn't technically in the development group.

/cc @gjtorikian 
