### PR TITLE
bin/github-markup: Follow symlinks to find installation folder.

### DIFF
--- a/bin/github-markup
+++ b/bin/github-markup
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift File.dirname(__FILE__) + "/../lib"
+$LOAD_PATH.unshift File.dirname(File.realpath(__FILE__)) + "/../lib"
 require 'github/markup'
 
 if ARGV[0] && File.exists?(file = ARGV[0])


### PR DESCRIPTION
I often add commands to my PATH by symlinking from $HOME/bin (instead of modifying the PATH variable).  This makes the github-markup command work in that situation.
