### PR TITLE
Resolve issues with the `tt` tag in MediaWiki

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -12,8 +12,8 @@ markup('github/markup/rdoc', /rdoc/) do |content|
 end
 
 markup('org-ruby', /org/) do |content|
-  Orgmode::Parser.new(content, { 
-                        :allow_include_files => false, 
+  Orgmode::Parser.new(content, {
+                        :allow_include_files => false,
                         :skip_syntax_highlight => true
                       }).to_html
 end
@@ -23,7 +23,9 @@ markup(:creole, /creole/) do |content|
 end
 
 markup(:wikicloth, /mediawiki|wiki/) do |content|
-  WikiCloth::WikiCloth.new(:data => content).to_html(:noedit => true)
+  wikicloth = WikiCloth::WikiCloth.new(:data => content)
+  WikiCloth::WikiBuffer::HTMLElement::ESCAPED_TAGS << 'tt'
+  wikicloth.to_html(:noedit => true)
 end
 
 markup(:asciidoctor, /adoc|asc(iidoc)?/) do |content|

--- a/test/markups/README.mediawiki
+++ b/test/markups/README.mediawiki
@@ -6,6 +6,9 @@ __TOC__
 
 = Red Bridge (JRuby Embed) =
 
+<tt>one-<two</tt>
+<pre>a-b</pre>
+
 JRuby has long had a private embedding API, which was closely tied to the runtime's internals and therefore changed frequently as JRuby evolved. Since version 1.4, however, we have also provided a more stable public API, known as Red Bridge or JRuby Embed. Existing Java programs written to the [[DirectJRubyEmbedding|legacy API]] should still work, but we strongly recommend Red Bridge for all new projects.
 
 == Features of Red Bridge ==

--- a/test/markups/README.mediawiki.html
+++ b/test/markups/README.mediawiki.html
@@ -18,6 +18,9 @@ Using Java from Ruby is JRuby's best-known feature---but you can also go in the 
 <a name="Red_Bridge_JRuby_Embed"></a>Red Bridge (JRuby Embed)</h1>
 
 
+<p><tt>one-&lt;two</tt>
+</p><pre>a-b</pre>
+
 
 <p>JRuby has long had a private embedding API, which was closely tied to the runtime's internals and therefore changed frequently as JRuby evolved. Since version 1.4, however, we have also provided a more stable public API, known as Red Bridge or JRuby Embed. Existing Java programs written to the <a href="DirectJRubyEmbedding">legacy API</a> should still work, but we strongly recommend Red Bridge for all new projects.
 </p>


### PR DESCRIPTION
Content can get to an unusable state if individuals write raw `<tt>` tags. This PR addresses that problem.

Edit: I forgot to note, here's the part in Wikicloth where escaped tags are defined, and where `tt` should be included: https://github.com/nricciar/wikicloth/blob/20daef07904eb9f53fccc3356aef4366497b98e9/lib/wikicloth/wiki_buffer/html_element.rb#L12

/cc @github/user-content 