### PR TITLE
The module is POSIX, not Posix

### DIFF
--- a/lib/github/markup/command_implementation.rb
+++ b/lib/github/markup/command_implementation.rb
@@ -36,8 +36,8 @@ module GitHub
           rendered
         end
       end
-      
-      if defined?(Posix::Spawn)
+
+      if defined?(POSIX::Spawn)
         def execute(command, target)
           spawn = POSIX::Spawn::Child.new(*command, :input => target)
           if spawn.status.success?
@@ -60,11 +60,11 @@ module GitHub
           sanitize(output.join(''), target.encoding)
         end
       end
-      
+
       def sanitize(input, encoding)
         input.gsub("\r", '').force_encoding(encoding)
       end
-      
+
     end
   end
 end


### PR DESCRIPTION
Ugh, took me forever to figure out why the latest github-markup wasn't working on production. The module is `POSIX`, not `Posix`.

Defined here: https://github.com/github/markup/commit/c272303f8bd1843a7cbcdec0e30052d445de325b#diff-02c4c8b8f144186ddb12a3d0a5853cd5

/cc @bkeepers @dometto 