### PR TITLE
Implement Rd parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-before_install: sudo pip install docutils
+before_install:
+  - sudo pip install docutils
+  - sudo apt-get install -qq r-base-core
 rvm:
   - 1.9.3
   - 2.0.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.asciidoc, .adoc, .asc](http://asciidoc.org/) -- `gem install asciidoctor` (http://asciidoctor.org)
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::HTML`
   comes with Perl >= 5.10. Lower versions should install [Pod::Simple](http://search.cpan.org/~dwheeler/Pod-Simple-3.28/lib/Pod/Simple.pod) from CPAN.
+* [.Rd](http://cran.r-project.org/doc/manuals/R-exts.html#Writing-R-documentation-files) -- `apt-get install r-base-core` (http://cran.r-project.org/index.html)
 
 Installation
 -----------

--- a/lib/github/commands/Rd2html
+++ b/lib/github/commands/Rd2html
@@ -1,0 +1,6 @@
+#!/bin/sh
+TMPFILE="/tmp/Rd2html.$$.tmp"
+
+cat > ${TMPFILE}
+/usr/bin/env R CMD Rdconv --type=html ${TMPFILE}
+rm -- ${TMPFILE}

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -42,3 +42,10 @@ command('/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go', /pod/)
     $1
   end
 end
+
+command("/bin/sh #{Shellwords.escape(File.dirname(__FILE__))}/commands/Rd2html", /Rd/) do |rendered|
+  # Strip away HTML header / footer
+  if rendered =~ /<body>(.+)<\/body>/mi
+    $1
+  end
+end

--- a/test/markups/README.Rd
+++ b/test/markups/README.Rd
@@ -1,0 +1,31 @@
+% File src/library/base/man/load.Rd
+\name{load}
+\alias{load}
+\title{Reload Saved Datasets}
+\description{
+  Reload the datasets written to a file with the function
+  \code{save}.
+}
+\usage{
+load(file, envir = parent.frame())
+}
+\arguments{
+  \item{file}{a connection or a character string giving the
+    name of the file to load.}
+  \item{envir}{the environment where the data should be
+    loaded.}
+}
+\seealso{
+  \code{\link{save}}.
+}
+\examples{
+## save all data
+save(list = ls(), file= "all.RData")
+
+## restore the saved values to the current environment
+load("all.RData")
+
+## restore the saved values to the workspace
+load("all.RData", .GlobalEnv)
+}
+\keyword{file}

--- a/test/markups/README.Rd.html
+++ b/test/markups/README.Rd.html
@@ -1,0 +1,55 @@
+<table width="100%" summary="page for load"><tr>
+<td>load</td>
+<td align="right">R Documentation</td>
+</tr></table>
+
+<h2>Reload Saved Datasets</h2>
+
+<h3>Description</h3>
+
+<p>Reload the datasets written to a file with the function
+<code>save</code>.
+</p>
+
+
+<h3>Usage</h3>
+
+<pre>
+load(file, envir = parent.frame())
+</pre>
+
+
+<h3>Arguments</h3>
+
+<table summary="R argblock">
+<tr valign="top"><td><code>file</code></td>
+<td>
+<p>a connection or a character string giving the
+name of the file to load.</p>
+</td></tr>
+<tr valign="top"><td><code>envir</code></td>
+<td>
+<p>the environment where the data should be
+loaded.</p>
+</td></tr>
+</table>
+
+
+<h3>See Also</h3>
+
+<p><code>save</code>.
+</p>
+
+
+<h3>Examples</h3>
+
+<pre>
+## save all data
+save(list = ls(), file= "all.RData")
+
+## restore the saved values to the current environment
+load("all.RData")
+
+## restore the saved values to the workspace
+load("all.RData", .GlobalEnv)
+</pre>


### PR DESCRIPTION
.Rd is a TeX-like language used for R documentation.

For this transformation to work, R (r-base-core in Debian) needs to be installed. There doesn't seem to be anywhere to note these dependencies, which I guess for Perl/Python doesn't matter so much, since you probably already have them. Not so likely for R. What would work best for you?

Merging would close #447.

More information on the format:
  http://cran.r-project.org/doc/manuals/R-exts.html#Writing-R-documentation-files