### PR TITLE
Symbol convenience render method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ pkg/
 .bundle
 Gemfile.lock
 vendor/
+.project
+.buildpath

--- a/README.md
+++ b/README.md
@@ -38,17 +38,30 @@ gem install github-markup
 Usage
 -----
 
+Basic form:
+
 ```ruby
 require 'github/markup'
-GitHub::Markup.render('README.markdown', "* One\n* Two")
+
+GitHub::Markup.render('README.markdown', '* One\n* Two')
 ```
 
-Or, more realistically:
+More realistic form:
 
 ```ruby
 require 'github/markup'
+
 GitHub::Markup.render(file, File.read(file))
 ```
+
+And a convenience form:
+
+```ruby
+require 'github/markup'
+
+GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, '* One\n* Two')
+```
+
 
 Contributing
 ------------

--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -2,6 +2,19 @@ require "github/markup/command_implementation"
 require "github/markup/gem_implementation"
 
 module GitHub
+  module Markups
+    # all of supported markups:
+    MARKUP_ASCIIDOC = :asciidoc
+    MARKUP_CREOLE = :creole
+    MARKUP_MARKDOWN = :markdown
+    MARKUP_MEDIAWIKI = :mediawiki
+    MARKUP_ORG = :org
+    MARKUP_POD = :pod
+    MARKUP_RDOC = :rdoc
+    MARKUP_RST = :rst
+    MARKUP_TEXTILE = :textile
+  end
+  
   module Markup
     extend self
     
@@ -42,10 +55,10 @@ module GitHub
     end
     
     def markup(symbol, file, pattern, opts = {}, &block)
-      markup(symbol, GemImplementation.new(pattern, file, &block))
+      markup_impl(symbol, GemImplementation.new(pattern, file, &block))
     end
     
-    def markup(symbol, impl)
+    def markup_impl(symbol, impl)
       if markups.has_key?(symbol)
         raise ArgumentError, "The '#{symbol}' symbol is already defined."
       end
@@ -57,7 +70,7 @@ module GitHub
         command = file
       end
 
-      markup(symbol, CommandImplementation.new(regexp, command, name, &block))
+      markup_impl(symbol, CommandImplementation.new(regexp, command, name, &block))
     end
 
     def can_render?(filename)

--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -4,14 +4,19 @@ require "github/markup/gem_implementation"
 module GitHub
   module Markup
     extend self
-    @@markups = []
+    
+    @@markups = {}
 
     def markups
       @@markups
     end
+    
+    def markup_impls
+      markups.values
+    end
 
     def preload!
-      markups.each do |markup|
+      markup_impls.each do |markup|
         markup.load
       end
     end
@@ -25,17 +30,34 @@ module GitHub
         content
       end
     end
-
-    def markup(file, pattern, opts = {}, &block)
-      markups << GemImplementation.new(pattern, file, &block)
+    
+    def render(symbol, content)
+      if content.nil?
+        raise ArgumentError, 'Can not render a nil.'
+      elsif markups.has_key?(symbol)
+        markups[symbol].render(content)
+      else
+        content
+      end
+    end
+    
+    def markup(symbol, file, pattern, opts = {}, &block)
+      markup(symbol, GemImplementation.new(pattern, file, &block))
+    end
+    
+    def markup(symbol, impl)
+      if markups.has_key?(symbol)
+        raise ArgumentError, "The '#{symbol}' symbol is already defined."
+      end
+      markups[symbol] = impl
     end
 
-    def command(command, regexp, name, &block)
+    def command(symbol, command, regexp, name, &block)
       if File.exist?(file = File.dirname(__FILE__) + "/commands/#{command}")
         command = file
       end
 
-      markups << CommandImplementation.new(regexp, command, name, &block)
+      markup(symbol, CommandImplementation.new(regexp, command, name, &block))
     end
 
     def can_render?(filename)
@@ -43,7 +65,7 @@ module GitHub
     end
 
     def renderer(filename)
-      markups.find { |impl|
+      markup_impls.find { |impl|
         impl.match?(filename)
       }
     end

--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -44,7 +44,7 @@ module GitHub
       end
     end
     
-    def render(symbol, content)
+    def render_s(symbol, content)
       if content.nil?
         raise ArgumentError, 'Can not render a nil.'
       elsif markups.has_key?(symbol)

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -2,50 +2,35 @@ require "github/markup/markdown"
 require "github/markup/rdoc"
 require "shellwords"
 
-module GitHub
-  module Markups
-    # all of supported markups:
-    MARKUP_ASCIIDOC = :asciidoc
-    MARKUP_CREOLE = :creole
-    MARKUP_MARKDOWN = :markdown
-    MARKUP_MEDIAWIKI = :mediawiki
-    MARKUP_ORG = :org
-    MARKUP_POD = :pod
-    MARKUP_RDOC = :rdoc
-    MARKUP_RST = :rst
-    MARKUP_TEXTILE = :textile
-  end
-end
+markup_impl(::GitHub::Markups::MARKUP_MARKDOWN, ::GitHub::Markup::Markdown.new)
 
-markup(GitHub::Markups::MARKUP_MARKDOWN, GitHub::Markup::Markdown.new)
-
-markup(GitHub::Markups::MARKUP_TEXTILE, :redcloth, /textile/) do |content|
+markup(::GitHub::Markups::MARKUP_TEXTILE, :redcloth, /textile/) do |content|
   RedCloth.new(content).to_html
 end
 
-markup(GitHub::Markups::MARKUP_RDOC, GitHub::Markup::RDoc.new)
+markup_impl(::GitHub::Markups::MARKUP_RDOC, GitHub::Markup::RDoc.new)
 
-markup(GitHub::Markups::MARKUP_ORG, 'org-ruby', /org/) do |content|
+markup(::GitHub::Markups::MARKUP_ORG, 'org-ruby', /org/) do |content|
   Orgmode::Parser.new(content, {
                         :allow_include_files => false,
                         :skip_syntax_highlight => true
                       }).to_html
 end
 
-markup(GitHub::Markups::MARKUP_CREOLE, :creole, /creole/) do |content|
+markup(::GitHub::Markups::MARKUP_CREOLE, :creole, /creole/) do |content|
   Creole.creolize(content)
 end
 
-markup(GitHub::Markups::MARKUP_MEDIAWIKI, :wikicloth, /mediawiki|wiki/) do |content|
+markup(::GitHub::Markups::MARKUP_MEDIAWIKI, :wikicloth, /mediawiki|wiki/) do |content|
   WikiCloth::WikiCloth.new(:data => content).to_html(:noedit => true)
 end
 
-markup(GitHub::Markups::MARKUP_ASCIIDOC, :asciidoctor, /adoc|asc(iidoc)?/) do |content|
+markup(::GitHub::Markups::MARKUP_ASCIIDOC, :asciidoctor, /adoc|asc(iidoc)?/) do |content|
   Asciidoctor.render(content, :safe => :secure, :attributes => %w(showtitle idprefix idseparator=- env=github env-github source-highlighter=html-pipeline))
 end
 
 command(
-  GitHub::Markups::MARKUP_RST,
+  ::GitHub::Markups::MARKUP_RST,
   "python2 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
   /re?st(\.txt)?/,
   "restructuredtext"
@@ -56,7 +41,7 @@ command(
 #
 # Any block passed to `command` will be handed the command's STDOUT for
 # post processing.
-command(GitHub::Markups::MARKUP_POD, '/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go', /pod/, "pod") do |rendered|
+command(::GitHub::Markups::MARKUP_POD, '/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go', /pod/, "pod") do |rendered|
   if rendered =~ /<!-- start doc -->\s*(.+)\s*<!-- end doc -->/mi
     $1
   end

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -2,34 +2,50 @@ require "github/markup/markdown"
 require "github/markup/rdoc"
 require "shellwords"
 
-markups << GitHub::Markup::Markdown.new
+module GitHub
+  module Markups
+    # all of supported markups:
+    MARKUP_ASCIIDOC = :asciidoc
+    MARKUP_CREOLE = :creole
+    MARKUP_MARKDOWN = :markdown
+    MARKUP_MEDIAWIKI = :mediawiki
+    MARKUP_ORG = :org
+    MARKUP_POD = :pod
+    MARKUP_RDOC = :rdoc
+    MARKUP_RST = :rst
+    MARKUP_TEXTILE = :textile
+  end
+end
 
-markup(:redcloth, /textile/) do |content|
+markup(GitHub::Markups::MARKUP_MARKDOWN, GitHub::Markup::Markdown.new)
+
+markup(GitHub::Markups::MARKUP_TEXTILE, :redcloth, /textile/) do |content|
   RedCloth.new(content).to_html
 end
 
-markups << GitHub::Markup::RDoc.new
+markup(GitHub::Markups::MARKUP_RDOC, GitHub::Markup::RDoc.new)
 
-markup('org-ruby', /org/) do |content|
+markup(GitHub::Markups::MARKUP_ORG, 'org-ruby', /org/) do |content|
   Orgmode::Parser.new(content, {
                         :allow_include_files => false,
                         :skip_syntax_highlight => true
                       }).to_html
 end
 
-markup(:creole, /creole/) do |content|
+markup(GitHub::Markups::MARKUP_CREOLE, :creole, /creole/) do |content|
   Creole.creolize(content)
 end
 
-markup(:wikicloth, /mediawiki|wiki/) do |content|
+markup(GitHub::Markups::MARKUP_MEDIAWIKI, :wikicloth, /mediawiki|wiki/) do |content|
   WikiCloth::WikiCloth.new(:data => content).to_html(:noedit => true)
 end
 
-markup(:asciidoctor, /adoc|asc(iidoc)?/) do |content|
+markup(GitHub::Markups::MARKUP_ASCIIDOC, :asciidoctor, /adoc|asc(iidoc)?/) do |content|
   Asciidoctor.render(content, :safe => :secure, :attributes => %w(showtitle idprefix idseparator=- env=github env-github source-highlighter=html-pipeline))
 end
 
 command(
+  GitHub::Markups::MARKUP_RST,
   "python2 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
   /re?st(\.txt)?/,
   "restructuredtext"
@@ -40,7 +56,7 @@ command(
 #
 # Any block passed to `command` will be handed the command's STDOUT for
 # post processing.
-command('/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go', /pod/, "pod") do |rendered|
+command(GitHub::Markups::MARKUP_POD, '/usr/bin/env perl -MPod::Simple::HTML -e Pod::Simple::HTML::go', /pod/, "pod") do |rendered|
   if rendered =~ /<!-- start doc -->\s*(.+)\s*<!-- end doc -->/mi
     $1
   end

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -98,7 +98,7 @@ message
   end
   
   def test_rendering_by_symbol
-    assert_equal "<b>test</b>", GitHub::Markup.render(GitHub::Markups::MARKUP_MARKDOWN, '**test**')
+    assert_equal '<p><code>test</code></p>', GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, '`test`').strip
   end
 
   def test_raises_error_if_command_exits_non_zero

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -75,7 +75,7 @@ class MarkupTest < Minitest::Test
 message
     end
   end
-
+  
   def test_knows_what_it_can_and_cannot_render
     assert_equal false, GitHub::Markup.can_render?('README.html')
     assert_equal true, GitHub::Markup.can_render?('README.markdown')
@@ -96,9 +96,13 @@ message
     assert_equal "restructuredtext", GitHub::Markup.renderer('README.rst').name
     assert_equal "pod", GitHub::Markup.renderer('README.pod').name
   end
+  
+  def test_rendering_by_symbol
+    assert_equal "<b>test</b>", GitHub::Markup.render(GitHub::Markups::MARKUP_MARKDOWN, '**test**')
+  end
 
   def test_raises_error_if_command_exits_non_zero
-    GitHub::Markup.command('test/fixtures/fail.sh', /fail/, 'fail')
+    GitHub::Markup.command(:doesntmatter, 'test/fixtures/fail.sh', /fail/, 'fail')
     assert GitHub::Markup.can_render?('README.fail')
     begin
       GitHub::Markup.render('README.fail', "stop swallowing errors")


### PR DESCRIPTION
Pull request in accordance with #483 .

Short description of changes:
- The `GitHub::Markup.render_s(symbol, content)` convenience method has been added. The primary intent behind this is for the gem's consumers to be able to define their own file associations for each markup without any "hacks" of the original `render` method.
- Consequently to the above, each markup now has a corresponding symbol constant defined (e.g. `GitHub::Markups::MARKUP_MARKDOWN`) that is to be used with the above method.
- Consequently to the above, each markup-rendering implementation is now "registered" with the above symbol constant (thus into a hash). Originally, they were registered "as is" (thus into an array).
- Consequently to the above, implementation of the `GitHub::Markup` interface has been reworked a little behind the scenes to integrate nicely with the above changes.
- A new test has been added to render some markdown with the new method. I don't think it's necessary to test all markups again with this method since they're already tested with the original `render` method.
- README has been updated to include the new convenience method.

Test (`rake`) results:
- `master` (unchanged) - 19 runs, 41 assertions, 2 failures, 4 errors, 0 skips
- `symbol-convenience-render-method` (changed) - 20 runs, 42 assertions, 2 failures, 4 errors, 0 skips
