### PR TITLE
Fix a couple of RST issues

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -48,7 +48,7 @@ from docutils.core import publish_parts
 from docutils.writers.html4css1 import Writer, HTMLTranslator
 
 SETTINGS = {
-    'cloak_email_addresses': True,
+    'cloak_email_addresses': False,
     'file_insertion_enabled': False,
     'raw_enabled': False,
     'strip_comments': True,

--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -44,6 +44,8 @@ except:
 
 import codecs
 
+from docutils import nodes
+from docutils.parsers.rst import roles
 from docutils.core import publish_parts
 from docutils.writers.html4css1 import Writer, HTMLTranslator
 
@@ -127,6 +129,10 @@ class GitHubHTMLTranslator(HTMLTranslator):
         self.body.append(self.starttag(node, 'img', **atts))
       self.body.append(self.context.pop())
 
+def kbd(name, rawtext, text, lineno, inliner, options=None, content=None):
+
+  return [nodes.raw('', '<kbd>%s</kbd>' % text, format='html')], []
+
 def main():
     """
     Parses the given ReST file or the redirected string input and returns the
@@ -144,6 +150,8 @@ def main():
 
     writer = Writer()
     writer.translator_class = GitHubHTMLTranslator
+
+    roles.register_canonical_role('kbd', kbd)
 
     parts = publish_parts(text, writer=writer, settings_overrides=SETTINGS)
     if 'html_body' in parts:

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -57,3 +57,5 @@ Field list
 :123456789 1234: this should work even with the default :)
 
 someone@somewhere.org
+
+Press :kbd:`Ctrl+C` to quit

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -55,3 +55,5 @@ Field list
 	but no problem!
 :123456789 12345: this is not so long, but long enough for the default!
 :123456789 1234: this should work even with the default :)
+
+someone@somewhere.org

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -73,3 +73,5 @@ but no problem!</td>
 </tr>
 </tbody>
 </table>
+
+<p><a href="mailto:someone@somewhere.org">someone@somewhere.org</a></p>

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -75,3 +75,5 @@ but no problem!</td>
 </table>
 
 <p><a href="mailto:someone@somewhere.org">someone@somewhere.org</a></p>
+
+<p>Press <kbd>Ctrl+C</kbd> to quit</p>


### PR DESCRIPTION
Super minor issues which people are asking for. 

Perhaps the more controversial change is unmasking email addresses, which has been in the code since 2009 ([the beginning](https://github.com/github/markup/blame/4691aece7cb7649f6d19168455fa49957633ad7f/lib/github/commands/rest2html#L51)). Given that no other converter masks emails, I think it's fine.

/cc @bkeepers @github/user-content 