### PR TITLE
Display unknown restructuredText directives

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -70,6 +70,7 @@ from docutils import nodes
 #    preferred viewer, e.g. at readthedocs.
 
 original_behavior = False  # Documents original docutils behavior
+github_display = True
 
 def unknown_directive(self, type_name):
     lineno = self.state_machine.abs_line_number()
@@ -81,8 +82,10 @@ def unknown_directive(self, type_name):
               'Unknown directive type "%s".' % type_name,
               nodes.literal_block(text, text), line=lineno)
         return [error], blank_finish
-    else:
+    elif github_display:
         return [nodes.literal_block(text, text)], blank_finish
+    else:
+        return [nodes.comment(text, text)], blank_finish
 
 def comment(self, match):
     if not match.string[match.end():].strip() \
@@ -92,11 +95,18 @@ def comment(self, match):
             self.state_machine.get_first_known_indented(match.end())
     while indented and not indented[-1].strip():
         indented.trim_end()
+    if not original_behavior:
+        firstline = ''.join(indented[:1]).split()
+        if ' '.join(firstline[:2]) == 'github display':
+            if len(firstline) == 3 and firstline[2] in ('on', 'off'):
+                global github_display
+                github_display = firstline[2] == 'on'
+            if len(indented) == 1:
+                return [nodes.comment()], 1
+            text = '\n'.join(indented[1:])
+            return [nodes.literal_block(text, text)], blank_finish
     text = '\n'.join(indented)
-    if original_behavior:
-        return [nodes.comment(text, text)], blank_finish
-    else:
-        return [nodes.literal_block(text, text)], blank_finish
+    return [nodes.comment(text, text)], blank_finish
 
 Body.comment = comment
 Body.unknown_directive = unknown_directive

--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -48,6 +48,59 @@ from docutils import nodes
 from docutils.parsers.rst import roles
 from docutils.core import publish_parts
 from docutils.writers.html4css1 import Writer, HTMLTranslator
+from docutils.parsers.rst.states import Body
+from docutils import nodes
+
+# By default, docutils provides two choices for unknown directives:
+#  - Show errors if the reporting level is high enough
+#  - Silently do not display them otherwise
+# Comments are not displayed, either.
+
+# This code monkey-patches docutils to show preformatted lines
+# in both these cases.
+
+# Recommended practice for repositories with rst files:
+#  - If github is the preferred viewer for the rst files (e.g. README.rst),
+#    then design the files to properly display for github.  E.g., do not
+#    include unknown directives or restructuredText comments.
+#  - If github is NOT the preferred viewer for the rst files (e.g.
+#    the files are designed to be used with sphinx extensions at readthedocs)
+#    then include a restructuredText comment at the top of the file
+#    explaining that the document will display much more nicely with its
+#    preferred viewer, e.g. at readthedocs.
+
+original_behavior = False  # Documents original docutils behavior
+
+def unknown_directive(self, type_name):
+    lineno = self.state_machine.abs_line_number()
+    indented, indent, offset, blank_finish = \
+        self.state_machine.get_first_known_indented(0, strip_indent=False)
+    text = '\n'.join(indented)
+    if original_behavior:
+        error = self.reporter.error(
+              'Unknown directive type "%s".' % type_name,
+              nodes.literal_block(text, text), line=lineno)
+        return [error], blank_finish
+    else:
+        return [nodes.literal_block(text, text)], blank_finish
+
+def comment(self, match):
+    if not match.string[match.end():].strip() \
+            and self.state_machine.is_next_line_blank(): # an empty comment?
+        return [nodes.comment()], 1 # "A tiny but practical wart."
+    indented, indent, offset, blank_finish = \
+            self.state_machine.get_first_known_indented(match.end())
+    while indented and not indented[-1].strip():
+        indented.trim_end()
+    text = '\n'.join(indented)
+    if original_behavior:
+        return [nodes.comment(text, text)], blank_finish
+    else:
+        return [nodes.literal_block(text, text)], blank_finish
+
+Body.comment = comment
+Body.unknown_directive = unknown_directive
+
 
 SETTINGS = {
     'cloak_email_addresses': False,

--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -83,7 +83,9 @@ def unknown_directive(self, type_name):
               nodes.literal_block(text, text), line=lineno)
         return [error], blank_finish
     elif github_display:
-        return [nodes.literal_block(text, text)], blank_finish
+        cls = ['unknown_directive']
+        result = [nodes.literal_block(text, text, classes=cls)]
+        return result, blank_finish
     else:
         return [nodes.comment(text, text)], blank_finish
 
@@ -104,7 +106,9 @@ def comment(self, match):
             if len(indented) == 1:
                 return [nodes.comment()], 1
             text = '\n'.join(indented[1:])
-            return [nodes.literal_block(text, text)], blank_finish
+            cls = ['github_comment']
+            result = [nodes.literal_block(text, text, classes=cls)]
+            return result, blank_finish
     text = '\n'.join(indented)
     return [nodes.comment(text, text)], blank_finish
 

--- a/test/markups/README.directives.rst
+++ b/test/markups/README.directives.rst
@@ -1,0 +1,103 @@
+==================================================
+restructuredText (rst) directives and comments
+==================================================
+
+Introduction
+=================
+
+An rst directive starts with two periods, and has a keyword
+followed by two colons, like this::
+
+    .. MyDirective::
+
+The rst parser is quite flexible and configurable.  Directives
+may be added for specialized operations.  Sphinx is a system
+that was designed for writing documentation, and, for example,
+readthedocs.org uses sphinx.
+
+Display of rst files at github needs to cover two distinct
+use-cases:
+
+- The github display is the primary method for displaying
+  the file (e.g. for README.rst files)
+
+- The github display is incidental to the primary method
+  for displaying the file (e.g. for readthedocs documentation)
+
+Currently, github handles the first case fine, but could
+confuse viewers for the second case, because sometimes
+content is missing from the github display.
+
+It would seem that one possibility for distinguishing these
+two cases is to add a github directive to control the display.
+
+Unfortunately, this would place a burden on every other rst
+parser to ignore the github directive (some of them will error
+on unknown directives).
+
+Instead, we can assign semantic content to specific comments.
+
+This is a fairly ugly hack, but it has the benefit of not
+requiring any document changes that would create problems with
+any conformant parser.
+
+
+The proposed special comment is::
+
+  .. github display [on | off]
+
+
+If you pass this the "on" value, then all unknown directives
+will be displayed as literal code blocks.  If you pass this
+the "off" value, then unknown directives will not be displayed.
+
+In addition to controlling the display of literal code blocks,
+this also allows you to show comments specifically for github.
+
+For example, somebody could place this at the top of their file::
+
+  .. github display
+
+    This file was designed to be viewed at readthedocs.  Some
+    content will not display properly when viewing using the
+    github browser.
+
+Tests
+==========
+
+By default, unknown directives should be displayed.
+
+.. UnknownDirective::  This is an unknown directive
+
+      it has a lot of stuff underneath it
+
+But we can turn this off, and the next directive should
+not be displayed.
+
+.. github display off
+
+.. UnknownDirective::  This is an unknown directive
+
+      it has a lot of stuff underneath it
+
+Or we can turn it back on...
+
+.. github display on
+
+.. UnknownDirective::  This is an unknown directive (3)
+
+      it has a lot of stuff underneath it
+
+Here is a comment that should display at github
+
+.. github display
+
+    YOU SHOULD SEE THIS!
+
+And here is a comment that should not display at github
+
+.. foobar
+
+    YOU SHOULD NOT SEE THIS!
+
+This concludes the tests.

--- a/test/markups/README.directives.rst.html
+++ b/test/markups/README.directives.rst.html
@@ -1,0 +1,75 @@
+<h1 class="title">restructuredText (rst) directives and comments</h1>
+<a name="introduction"></a>
+<h2>Introduction</h2>
+<p>An rst directive starts with two periods, and has a keyword
+followed by two colons, like this:</p>
+<pre>
+.. MyDirective::
+</pre>
+<p>The rst parser is quite flexible and configurable.  Directives
+may be added for specialized operations.  Sphinx is a system
+that was designed for writing documentation, and, for example,
+readthedocs.org uses sphinx.</p>
+<p>Display of rst files at github needs to cover two distinct
+use-cases:</p>
+<ul class="simple">
+<li>The github display is the primary method for displaying
+the file (e.g. for README.rst files)</li>
+<li>The github display is incidental to the primary method
+for displaying the file (e.g. for readthedocs documentation)</li>
+</ul>
+<p>Currently, github handles the first case fine, but could
+confuse viewers for the second case, because sometimes
+content is missing from the github display.</p>
+<p>It would seem that one possibility for distinguishing these
+two cases is to add a github directive to control the display.</p>
+<p>Unfortunately, this would place a burden on every other rst
+parser to ignore the github directive (some of them will error
+on unknown directives).</p>
+<p>Instead, we can assign semantic content to specific comments.</p>
+<p>This is a fairly ugly hack, but it has the benefit of not
+requiring any document changes that would create problems with
+any conformant parser.</p>
+<p>The proposed special comment is:</p>
+<pre>
+.. github display [on | off]
+</pre>
+<p>If you pass this the &quot;on&quot; value, then all unknown directives
+will be displayed as literal code blocks.  If you pass this
+the &quot;off&quot; value, then unknown directives will not be displayed.</p>
+<p>In addition to controlling the display of literal code blocks,
+this also allows you to show comments specifically for github.</p>
+<p>For example, somebody could place this at the top of their file:</p>
+<pre>
+.. github display
+
+  This file was designed to be viewed at readthedocs.  Some
+  content will not display properly when viewing using the
+  github browser.
+</pre>
+<a name="tests"></a>
+<h2>Tests</h2>
+<p>By default, unknown directives should be displayed.</p>
+<pre>
+.. UnknownDirective::  This is an unknown directive
+
+      it has a lot of stuff underneath it
+
+</pre>
+<p>But we can turn this off, and the next directive should
+not be displayed.</p>
+<p>Or we can turn it back on...</p>
+<pre>
+.. UnknownDirective::  This is an unknown directive (3)
+
+      it has a lot of stuff underneath it
+
+</pre>
+<p>Here is a comment that should display at github</p>
+<pre>
+
+YOU SHOULD SEE THIS!
+</pre>
+<p>And here is a comment that should not display at github</p>
+<p>This concludes the tests.</p>
+

--- a/test/markups/README.directives.rst.html
+++ b/test/markups/README.directives.rst.html
@@ -1,4 +1,4 @@
-<h1 class="title">restructuredText (rst) directives and comments</h1>
+<h1>restructuredText (rst) directives and comments</h1>
 <a name="introduction"></a>
 <h2>Introduction</h2>
 <p>An rst directive starts with two periods, and has a keyword
@@ -12,7 +12,7 @@ that was designed for writing documentation, and, for example,
 readthedocs.org uses sphinx.</p>
 <p>Display of rst files at github needs to cover two distinct
 use-cases:</p>
-<ul class="simple">
+<ul>
 <li>The github display is the primary method for displaying
 the file (e.g. for README.rst files)</li>
 <li>The github display is incidental to the primary method
@@ -34,9 +34,9 @@ any conformant parser.</p>
 <pre>
 .. github display [on | off]
 </pre>
-<p>If you pass this the &quot;on&quot; value, then all unknown directives
+<p>If you pass this the "on" value, then all unknown directives
 will be displayed as literal code blocks.  If you pass this
-the &quot;off&quot; value, then unknown directives will not be displayed.</p>
+the "off" value, then unknown directives will not be displayed.</p>
 <p>In addition to controlling the display of literal code blocks,
 this also allows you to show comments specifically for github.</p>
 <p>For example, somebody could place this at the top of their file:</p>
@@ -72,4 +72,3 @@ YOU SHOULD SEE THIS!
 </pre>
 <p>And here is a comment that should not display at github</p>
 <p>This concludes the tests.</p>
-

--- a/test/markups/README.directives.rst.html
+++ b/test/markups/README.directives.rst.html
@@ -1,4 +1,4 @@
-<h1>restructuredText (rst) directives and comments</h1>
+<h1 class="title">restructuredText (rst) directives and comments</h1>
 <a name="introduction"></a>
 <h2>Introduction</h2>
 <p>An rst directive starts with two periods, and has a keyword
@@ -12,7 +12,7 @@ that was designed for writing documentation, and, for example,
 readthedocs.org uses sphinx.</p>
 <p>Display of rst files at github needs to cover two distinct
 use-cases:</p>
-<ul>
+<ul class="simple">
 <li>The github display is the primary method for displaying
 the file (e.g. for README.rst files)</li>
 <li>The github display is incidental to the primary method
@@ -34,9 +34,9 @@ any conformant parser.</p>
 <pre>
 .. github display [on | off]
 </pre>
-<p>If you pass this the "on" value, then all unknown directives
+<p>If you pass this the &quot;on&quot; value, then all unknown directives
 will be displayed as literal code blocks.  If you pass this
-the "off" value, then unknown directives will not be displayed.</p>
+the &quot;off&quot; value, then unknown directives will not be displayed.</p>
 <p>In addition to controlling the display of literal code blocks,
 this also allows you to show comments specifically for github.</p>
 <p>For example, somebody could place this at the top of their file:</p>
@@ -72,3 +72,4 @@ YOU SHOULD SEE THIS!
 </pre>
 <p>And here is a comment that should not display at github</p>
 <p>This concludes the tests.</p>
+


### PR DESCRIPTION
This addresses issue #514.

Previous behavior was to silently ignore unknown directives and
comments, which made .rst documents that utilized rst extensions
appear to be incomplete.  This fix allows all the information to
be displayed, and further allows comments to be placed to indicate
that the github rst viewer is not the preferred viewer for the
document.

This patch will not alter the appearance of any document that
is specifically coded for display at github which doesn't use
restucturedText comments.

Additional possible enhancements include figuring out how to
gray out this text, and/or to support a special github directive
at the start of the text file that controls whether this new
behavior is enabled.
