### PR TITLE
Raw html support in rst

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -52,7 +52,7 @@ from docutils.writers.html4css1 import Writer, HTMLTranslator
 SETTINGS = {
     'cloak_email_addresses': False,
     'file_insertion_enabled': False,
-    'raw_enabled': False,
+    'raw_enabled': True,
     'strip_comments': True,
     'doctitle_xform': True,
     'sectsubtitle_xform': True,

--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -58,18 +58,20 @@ SETTINGS = {
     'sectsubtitle_xform': True,
     'initial_header_level': 2,
     'report_level': 5,
-    'syntax_highlight' : 'none',
-    'math_output' : 'latex',
+    'syntax_highlight': 'none',
+    'math_output': 'latex',
     'field_name_limit': 50,
 }
 
+
 class GitHubHTMLTranslator(HTMLTranslator):
+
     # removes the <div class="document"> tag wrapped around docs
     # see also: http://bit.ly/1exfq2h (warning! sourceforge link.)
     def depart_document(self, node):
         HTMLTranslator.depart_document(self, node)
-        self.html_body.pop(0) # pop the starting <div> off
-        self.html_body.pop() # pop the ending </div> off
+        self.html_body.pop(0)  # pop the starting <div> off
+        self.html_body.pop()   # pop the ending </div> off
 
     # technique for visiting sections, without generating additional divs
     # see also: http://bit.ly/NHtyRx
@@ -102,36 +104,38 @@ class GitHubHTMLTranslator(HTMLTranslator):
     def visit_table(self, node):
         classes = ' '.join(['docutils', self.settings.table_style]).strip()
         self.body.append(
-                self.starttag(node, 'table', CLASS=classes))
+            self.starttag(node, 'table', CLASS=classes))
 
     def depart_table(self, node):
         self.body.append('</table>\n')
 
     def depart_image(self, node):
-      uri = node['uri']
-      ext = os.path.splitext(uri)[1].lower()
-      # we need to swap RST's use of `object` with `img` tags
-      # see http://git.io/5me3dA
-      if ext == ".svg":
-        # preserve essential attributes
-        atts = {}
-        for attribute, value in  node.attributes.items():
-          # we have no time for empty values
-          if value:
-            if attribute == "uri":
-              atts['src'] = value
-            else:
-              atts[attribute] = value
+        uri = node['uri']
+        ext = os.path.splitext(uri)[1].lower()
+        # we need to swap RST's use of `object` with `img` tags
+        # see http://git.io/5me3dA
+        if ext == ".svg":
+            # preserve essential attributes
+            atts = {}
+            for attribute, value in node.attributes.items():
+                # we have no time for empty values
+                if value:
+                    if attribute == "uri":
+                        atts['src'] = value
+                    else:
+                        atts[attribute] = value
 
-        # toss off `object` tag
-        self.body.pop()
+            # toss off `object` tag
+            self.body.pop()
         # add on `img` with attributes
-        self.body.append(self.starttag(node, 'img', **atts))
-      self.body.append(self.context.pop())
+            self.body.append(self.starttag(node, 'img', **atts))
+        self.body.append(self.context.pop())
+
 
 def kbd(name, rawtext, text, lineno, inliner, options=None, content=None):
 
-  return [nodes.raw('', '<kbd>%s</kbd>' % text, format='html')], []
+    return [nodes.raw('', '<kbd>%s</kbd>' % text, format='html')], []
+
 
 def main():
     """
@@ -143,9 +147,9 @@ def main():
     """
     try:
         text = codecs.open(sys.argv[1], 'r', 'utf-8').read()
-    except IOError: # given filename could not be found
+    except IOError:  # given filename could not be found
         return ''
-    except IndexError: # no filename given
+    except IndexError:  # no filename given
         text = sys.stdin.read()
 
     writer = Writer()


### PR DESCRIPTION
Description of changes:

* pep8 compliance (commit https://github.com/github/markup/commit/f34f5387f10ff784a3c62bb5f73bb236354f6f7b)
* Enable raw html (commit https://github.com/github/markup/commit/68557d2756e62cf5a12f4648dcc36dc99169645f)

Is there a reason to have disabled raw html handling of rst in the first place?