### PR TITLE
Use Linguist to detect the language

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,4 @@ gem "wikicloth", "=0.8.3"
 gem "asciidoctor", "= 1.5.2"
 gem "rake"
 gem "rinku", '~> 1'
+gem "github-linguist", ">= 4.7.5"

--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -37,7 +37,7 @@ module GitHub
     def render(filename, content = nil)
       content ||= File.read(filename)
 
-      if impl = renderer(filename)
+      if impl = renderer(filename, content)
         impl.render(content)
       else
         content
@@ -53,9 +53,9 @@ module GitHub
         content
       end
     end
-    
-    def markup(symbol, file, pattern, opts = {}, &block)
-      markup_impl(symbol, GemImplementation.new(pattern, file, &block))
+
+    def markup(symbol, gem_name, pattern, opts = {}, &block)
+      markup_impl(symbol, GemImplementation.new(pattern, gem_name, &block))
     end
     
     def markup_impl(symbol, impl)
@@ -65,22 +65,28 @@ module GitHub
       markups[symbol] = impl
     end
 
-    def command(symbol, command, regexp, name, &block)
+    def command(symbol, command, languages, name, &block)
       if File.exist?(file = File.dirname(__FILE__) + "/commands/#{command}")
         command = file
       end
 
-      markup_impl(symbol, CommandImplementation.new(regexp, command, name, &block))
+      markup_impl(symbol, CommandImplementation.new(languages, command, name, &block))
     end
 
-    def can_render?(filename)
-      !!renderer(filename)
+    def can_render?(filename, content)
+      !!renderer(filename, content)
     end
 
-    def renderer(filename)
+    def renderer(filename, content)
+      language = language(filename, content)
       markup_impls.find { |impl|
-        impl.match?(filename)
+        impl.match?(language)
       }
+    end
+
+    def language(filename, content)
+      blob = Linguist::Blob.new(filename, content)
+      return Linguist.detect(blob)
     end
 
     # Define markups

--- a/lib/github/markup/command_implementation.rb
+++ b/lib/github/markup/command_implementation.rb
@@ -15,8 +15,8 @@ module GitHub
     class CommandImplementation < Implementation
       attr_reader :command, :block, :name
 
-      def initialize(regexp, command, name, &block)
-        super regexp
+      def initialize(languages, command, name, &block)
+        super languages
         @command = command.to_s
         @block = block
         @name = name

--- a/lib/github/markup/gem_implementation.rb
+++ b/lib/github/markup/gem_implementation.rb
@@ -5,8 +5,8 @@ module GitHub
     class GemImplementation < Implementation
       attr_reader :gem_name, :renderer
 
-      def initialize(regexp, gem_name, &renderer)
-        super regexp
+      def initialize(languages, gem_name, &renderer)
+        super languages
         @gem_name = gem_name.to_s
         @renderer = renderer
       end

--- a/lib/github/markup/implementation.rb
+++ b/lib/github/markup/implementation.rb
@@ -1,10 +1,10 @@
 module GitHub
   module Markup
     class Implementation
-      attr_reader :regexp
+      attr_reader :languages
 
-      def initialize(regexp)
-        @regexp = regexp
+      def initialize(languages)
+        @languages = languages
       end
 
       def load
@@ -15,13 +15,8 @@ module GitHub
         raise NotImplementedError, "subclasses of GitHub::Markup::Implementation must define #render"
       end
 
-      def match?(filename)
-        file_ext_regexp =~ filename
-      end
-
-    private
-      def file_ext_regexp
-        @file_ext_regexp ||= /\.(#{regexp})\z/
+      def match?(language)
+        languages.include? language
       end
     end
   end

--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -28,7 +28,7 @@ module GitHub
       }
 
       def initialize
-        super(/md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee/i)
+        super([Linguist::Language["Markdown"], Linguist::Language["RMarkdown"], Linguist::Language["Literate CoffeeScript"]])
       end
 
       def load

--- a/lib/github/markup/rdoc.rb
+++ b/lib/github/markup/rdoc.rb
@@ -6,7 +6,7 @@ module GitHub
   module Markup
     class RDoc < Implementation
       def initialize
-        super(/rdoc/)
+        super([Linguist::Language["RDoc"]])
       end
 
       def render(content)

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -1,33 +1,34 @@
 require "github/markup/markdown"
 require "github/markup/rdoc"
 require "shellwords"
+require "linguist"
 
 markup_impl(::GitHub::Markups::MARKUP_MARKDOWN, ::GitHub::Markup::Markdown.new)
 
-markup(::GitHub::Markups::MARKUP_TEXTILE, :redcloth, /textile/) do |content|
+markup(::GitHub::Markups::MARKUP_TEXTILE, :redcloth, [Linguist::Language["Textile"]]) do |content|
   RedCloth.new(content).to_html
 end
 
 markup_impl(::GitHub::Markups::MARKUP_RDOC, GitHub::Markup::RDoc.new)
 
-markup(::GitHub::Markups::MARKUP_ORG, 'org-ruby', /org/) do |content|
+markup(::GitHub::Markups::MARKUP_ORG, 'org-ruby', [Linguist::Language["Org"]]) do |content|
   Orgmode::Parser.new(content, {
                         :allow_include_files => false,
                         :skip_syntax_highlight => true
                       }).to_html
 end
 
-markup(::GitHub::Markups::MARKUP_CREOLE, :creole, /creole/) do |content|
+markup(::GitHub::Markups::MARKUP_CREOLE, :creole, [Linguist::Language["Creole"]]) do |content|
   Creole.creolize(content)
 end
 
-markup(::GitHub::Markups::MARKUP_MEDIAWIKI, :wikicloth, /mediawiki|wiki/) do |content|
+markup(::GitHub::Markups::MARKUP_MEDIAWIKI, :wikicloth, [Linguist::Language["MediaWiki"]]) do |content|
   wikicloth = WikiCloth::WikiCloth.new(:data => content)
   WikiCloth::WikiBuffer::HTMLElement::ESCAPED_TAGS << 'tt' unless WikiCloth::WikiBuffer::HTMLElement::ESCAPED_TAGS.include?('tt')
   wikicloth.to_html(:noedit => true)
 end
 
-markup(::GitHub::Markups::MARKUP_ASCIIDOC, :asciidoctor, /adoc|asc(iidoc)?/) do |content|
+markup(::GitHub::Markups::MARKUP_ASCIIDOC, :asciidoctor, [Linguist::Language["AsciiDoc"]]) do |content|
   Asciidoctor::Compliance.unique_id_start_index = 1
   Asciidoctor.convert(content, :safe => :secure, :attributes => %w(showtitle=@ idprefix idseparator=- env=github env-github source-highlighter=html-pipeline))
 end
@@ -35,8 +36,8 @@ end
 command(
   ::GitHub::Markups::MARKUP_RST,
   "python2 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
-  /re?st(\.txt)?/,
+  [Linguist::Language["reStructuredText"]],
   "restructuredtext"
 )
 
-command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, "pod")
+command(::GitHub::Markups::MARKUP_POD, :pod2html, [Linguist::Language["Pod"]], "pod")

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -77,24 +77,24 @@ message
   end
   
   def test_knows_what_it_can_and_cannot_render
-    assert_equal false, GitHub::Markup.can_render?('README.html')
-    assert_equal true, GitHub::Markup.can_render?('README.markdown')
-    assert_equal true, GitHub::Markup.can_render?('README.rmd')
-    assert_equal true, GitHub::Markup.can_render?('README.Rmd')
-    assert_equal false, GitHub::Markup.can_render?('README.cmd')
-    assert_equal true, GitHub::Markup.can_render?('README.litcoffee')
+    assert_equal false, GitHub::Markup.can_render?('README.html', '<h1>Title</h1>')
+    assert_equal true, GitHub::Markup.can_render?('README.markdown', '=== Title')
+    assert_equal true, GitHub::Markup.can_render?('README.rmd', '=== Title')
+    assert_equal true, GitHub::Markup.can_render?('README.Rmd', '=== Title')
+    assert_equal false, GitHub::Markup.can_render?('README.cmd', 'echo 1')
+    assert_equal true, GitHub::Markup.can_render?('README.litcoffee', 'Title')
   end
 
   def test_each_render_has_a_name
-    assert_equal "markdown", GitHub::Markup.renderer('README.md').name
-    assert_equal "redcloth", GitHub::Markup.renderer('README.textile').name
-    assert_equal "rdoc", GitHub::Markup.renderer('README.rdoc').name
-    assert_equal "org-ruby", GitHub::Markup.renderer('README.org').name
-    assert_equal "creole", GitHub::Markup.renderer('README.creole').name
-    assert_equal "wikicloth", GitHub::Markup.renderer('README.wiki').name
-    assert_equal "asciidoctor", GitHub::Markup.renderer('README.adoc').name
-    assert_equal "restructuredtext", GitHub::Markup.renderer('README.rst').name
-    assert_equal "pod", GitHub::Markup.renderer('README.pod').name
+    assert_equal "markdown", GitHub::Markup.renderer('README.md', '=== Title').name
+    assert_equal "redcloth", GitHub::Markup.renderer('README.textile', '* One').name
+    assert_equal "rdoc", GitHub::Markup.renderer('README.rdoc', '* One').name
+    assert_equal "org-ruby", GitHub::Markup.renderer('README.org', '* Title').name
+    assert_equal "creole", GitHub::Markup.renderer('README.creole', '= Title =').name
+    assert_equal "wikicloth", GitHub::Markup.renderer('README.wiki', '<h1>Title</h1>').name
+    assert_equal "asciidoctor", GitHub::Markup.renderer('README.adoc', '== Title').name
+    assert_equal "restructuredtext", GitHub::Markup.renderer('README.rst', 'Title').name
+    assert_equal "pod", GitHub::Markup.renderer('README.pod', '=begin').name
   end
   
   def test_rendering_by_symbol
@@ -102,10 +102,10 @@ message
   end
 
   def test_raises_error_if_command_exits_non_zero
-    GitHub::Markup.command(:doesntmatter, 'test/fixtures/fail.sh', /fail/, 'fail')
-    assert GitHub::Markup.can_render?('README.fail')
+    GitHub::Markup.command(:doesntmatter, 'test/fixtures/fail.sh', [Linguist::Language['Java']], 'fail')
+    assert GitHub::Markup.can_render?('README.java', 'stop swallowing errors')
     begin
-      GitHub::Markup.render('README.fail', "stop swallowing errors")
+      GitHub::Markup.render('README.java', "stop swallowing errors")
     rescue GitHub::Markup::CommandError => e
       assert_equal "failure message", e.message
     else


### PR DESCRIPTION
As discussed in github/linguist#2497, this pull requests makes use of `Linguist::Blob` to detect the language of a markup document.

`Linguist::Blob` is not yet part of Linguist and this pull request still has failing tests so it's work in progress.

/cc @bkeepers 
