### PR TITLE
Added doctest blocks to reStructuredText (with tests)

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -45,7 +45,8 @@ except:
 import codecs
 
 from docutils import nodes
-from docutils.parsers.rst import roles
+from docutils.parsers.rst import directives, roles
+from docutils.parsers.rst.directives.body import CodeBlock
 from docutils.core import publish_parts
 from docutils.writers.html4css1 import Writer, HTMLTranslator
 
@@ -62,6 +63,18 @@ SETTINGS = {
     'math_output' : 'latex',
     'field_name_limit': 50,
 }
+
+
+class DoctestDirective(CodeBlock):
+    """Render Sphinx 'doctest:: [group]' blocks as 'code:: python'
+    """
+
+    def run(self):
+        """Discard any doctest group argument, render contents as python code
+        """
+        self.arguments = ['python']
+        return super(DoctestDirective, self).run()
+
 
 class GitHubHTMLTranslator(HTMLTranslator):
     # removes the <div class="document"> tag wrapped around docs
@@ -152,6 +165,9 @@ def main():
     writer.translator_class = GitHubHTMLTranslator
 
     roles.register_canonical_role('kbd', kbd)
+
+    # Render source code in Sphinx doctest blocks
+    directives.register_directive('doctest', DoctestDirective)
 
     parts = publish_parts(text, writer=writer, settings_overrides=SETTINGS)
     if 'html_body' in parts:

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -31,6 +31,19 @@ The UTF-8 quote character in this table used to cause python to go boom. Now doc
 	Tabular Data, 5
 	Made up ratings, 11
 
+.. code::
+
+	A block of code
+
+.. code:: python
+
+	python.code('hooray')
+
+.. doctest:: ignored
+
+	>>> some_function()
+	'result'
+
 ==============  ==========================================================
 Travis          http://travis-ci.org/tony/pullv
 Docs            http://pullv.rtfd.org

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -16,6 +16,16 @@
 <li>Somé UTF-8°</li>
 </ol>
 <p>The UTF-8 quote character in this table used to cause python to go boom. Now docutils just silently ignores it.</p>
+<pre>
+A block of code
+</pre>
+<pre lang="python">
+python.code('hooray')
+</pre>
+<pre lang="python">
+&gt;&gt;&gt; some_function()
+'result'
+</pre>
 <table>
 
 


### PR DESCRIPTION
This PR:
 - Renders reStructuredText `doctest::` blocks as `code::` blocks

Many Python projects use [Sphinx](http://sphinx-doc.org/) to create documentation from `.rst` markup.

Using a [doctest::](http://sphinx-doc.org/ext/doctest.html?#directive-doctest) directive the markup can include blocks of code that is both tested, and rendered in the final documentation. However these blocks are not rendered on github.com, e.g. in a `README.rst`.

To remedy this (without adding Sphinx as a dependency) this PR aliases `doctest::` directives to `code::` directives. The language of such blocks is set to 'python', since doctest only supports Python.

Refs dateutil/dateutil#83