### PR TITLE
allow multiple files for command line tool

### DIFF
--- a/bin/github-markup
+++ b/bin/github-markup
@@ -5,7 +5,7 @@ require 'github/markup'
 
 if ARGV.size < 1
   print "usage: #$0 FILE [ FILES ... ]\n"
-  exit
+  exit 1
 end
 
 sources = []
@@ -15,13 +15,13 @@ ARGV.each { |s|
     file = File.open( s, "r" )
     sources.push [ s, file ]
   rescue Exception => e
-    print "error: #{e.message}\n"
+    $stderr.print "error: #{e.message}\n"
+    exit 1
   ensure
   end
 }
 
-sources.each { |s|
-  name,file = s
+sources.each { |name, file|
   print GitHub::Markup.render( name, file.read )
   file.close
 }

--- a/bin/github-markup
+++ b/bin/github-markup
@@ -3,8 +3,26 @@
 $LOAD_PATH.unshift File.dirname(__FILE__) + "/../lib"
 require 'github/markup'
 
-if ARGV[0] && File.exists?(file = ARGV[0])
-  puts GitHub::Markup.render(file)
-else
-  puts "usage: #$0 FILE"
+if ARGV.size < 1
+  print "usage: #$0 FILE [ FILES ... ]\n"
+  exit
 end
+
+sources = []
+
+ARGV.each { |s|
+  begin
+    file = File.open( s, "r" )
+    sources.push [ s, file ]
+  rescue Exception => e
+    print "error: #{e.message}\n"
+  ensure
+  end
+}
+
+sources.each { |s|
+  name,file = s
+  print GitHub::Markup.render( name, file.read )
+  file.close
+}
+


### PR DESCRIPTION
useful for prepare for printing multiple documents:
github-markup repo/docs/*
instead of
echo repo/docs/\* | xargs github-markup
