### PR TITLE
RestructuredText (rst): Remove the sectsubtitle_xform setting

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -56,7 +56,6 @@ SETTINGS = {
     'raw_enabled': True,
     'strip_comments': True,
     'doctitle_xform': True,
-    'sectsubtitle_xform': True,
     'initial_header_level': 2,
     'report_level': 5,
     'syntax_highlight': 'none',


### PR DESCRIPTION
Fixes #953.

As stated in PR #279, three settings (`doctitle_xform=True`, `sectsubtitle_xform=True`, `initial_header_level=2`) are necessary to render table of contents the right way.
But actually the combination of `doctitle_xform=True` and `initial_header_level=2` is sufficient.

With non-overriden `sectsubtitle_xform` (by default, it is `False`) the "Subsection 1" in [this example](https://gist.github.com/hcpl/f2972cb5129015ccfc64562d568ed803#file-readme-rst) will be rendered on the same level as "Subsection 2". Besides that, the table of contents will show "Subsection 1" in the appropriate position. See the [HTML output](https://gist.github.com/hcpl/f2972cb5129015ccfc64562d568ed803#file-readme-rst-original-html) of [rest2html](https://github.com/github/markup/blob/master/lib/github/commands/rest2html) after applying this PR.

It should be noted that this PR does not abandon results of the PR #279, as titles and subtitles will not be converted to sections and subsections.