### PR TITLE
Added support for highlighting doctest blocks in reStructuredText files.

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -105,6 +105,9 @@ class GitHubHTMLTranslator(HTMLTranslator):
         else:
             self.body.append(self.starttag(node, 'pre'))
 
+    def visit_doctest_block(self, node):
+        self.body.append(self.starttag(node, 'pre', lang='pycon'))
+
     # always wrap two-backtick rst inline literals in <code>, not <tt>
     # this also avoids the generation of superfluous <span> tags
     def visit_literal(self, node):

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -44,6 +44,9 @@ The UTF-8 quote character in this table used to cause python to go boom. Now doc
 	>>> some_function()
 	'result'
 
+>>> some_function()
+'result'
+
 ==============  ==========================================================
 Travis          http://travis-ci.org/tony/pullv
 Docs            http://pullv.rtfd.org

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -26,6 +26,10 @@ python.code('hooray')
 &gt;&gt;&gt; some_function()
 'result'
 </pre>
+<pre lang="pycon">
+&gt;&gt;&gt; some_function()
+'result'
+</pre>
 <table>
 
 


### PR DESCRIPTION
It would be nice to have syntax highlighting for [doctest blocks](http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#doctest-blocks) in *.rst files.

I changed it so that the `<pre>` tag gets a `lang="pycon"` attribute for doctest blocks.

This should hopefully result in highlighting for those.