### PR TITLE
Make rest2html work with docutils 0.13

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -139,9 +139,9 @@ class GitHubHTMLTranslator(HTMLTranslator):
 
             # toss off `object` tag
             self.body.pop()
-        # add on `img` with attributes
+            # add on `img` with attributes
             self.body.append(self.starttag(node, 'img', **atts))
-        self.body.append(self.context.pop())
+        HTMLTranslator.depart_image(self, node)
 
 
 def kbd(name, rawtext, text, lineno, inliner, options=None, content=None):


### PR DESCRIPTION
In that docutils version, `HTMLTranslator.visit_image` [no longer appends empty string to self.context](https://sourceforge.net/p/docutils/code/7799/), so trying to `pop()` from there raises an IndexError.

Instead of the hard-coded `pop` call, call the overridden method, which will call `pop()` on docutils 0.12 and will do nothing on docutils 0.13.

Fixes #971.

Also, fix the comment indentation.