### PR TITLE
Link directly to pod pages on metacpan

### DIFF
--- a/lib/github/commands/pod2html
+++ b/lib/github/commands/pod2html
@@ -6,7 +6,7 @@ use Pod::Simple::XHTML 3.11;
 my $p = Pod::Simple::XHTML->new;
 $p->html_header('');
 $p->html_footer('');
-$p->perldoc_url_prefix('http://metacpan.org/search?q=');
+$p->perldoc_url_prefix('https://metacpan.org/pod/');
 $p->strip_verbatim_indent(sub {
     my $lines = shift;
     (my $indent = $lines->[0]) =~ s/\S.*//;


### PR DESCRIPTION
The /pod/ URL prefix should provide a more direct link to module documentation.