### PR TITLE
Remove superfluous dependency on rinku, fix jruby

### DIFF
--- a/github-markup.gemspec
+++ b/github-markup.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = %w[lib]
 
-  s.add_dependency "rinku"
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'activesupport', '~> 4.0'
   s.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'


### PR DESCRIPTION
This PR removes the dependency on the `rinku` gem from the `.gemspec`. This is because this dependency [breaks support for jruby](https://travis-ci.org/gollum/gollum-lib/jobs/215996345), and appears to be superfluous. (The dependency on `github-linguist` was just made optional in order to fix jruby support in #537 by @kivikakk -- however, I had overlooked the additional breaking dependency on `rinku`)

The dependency on `rinku` was first introduced into the `Gemfile` in https://github.com/github/markup/commit/e494209fea8568455e563840a6a4f955d2162d07, and then turned into a hard dependency in the `.gemspec` in https://github.com/github/markup/commit/40023768d4d8ca719da3637857a435733ae53f61. It is unclear what the motivation for including `rinku` was in either case. The project does not appear to use it:

```
$ grep -ri rinku .
./github-markup.gemspec:  s.add_dependency "rinku"
```

/cc @bartkamphorst