### PR TITLE
doc fix example with newline interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Basic form:
 ```ruby
 require 'github/markup'
 
-GitHub::Markup.render('README.markdown', '* One\n* Two')
+GitHub::Markup.render('README.markdown', "* One\n* Two")
 ```
 
 More realistic form:
@@ -62,7 +62,7 @@ And a convenience form:
 ```ruby
 require 'github/markup'
 
-GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, '* One\n* Two')
+GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, "* One\n* Two")
 ```
 
 


### PR DESCRIPTION
as is with single quotes, the example renders:

```html
<ul>
<li>One* Two</li>
</ul>
```
using double quotes interprets the newline correctly:

```html
<ul>
<li>One</li>
<li>Two</li>
</ul>
```