### PR TITLE
Adjust initial_header_level for TOC

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -126,7 +126,7 @@ SETTINGS = {
     'raw_enabled': True,
     'strip_comments': True,
     'doctitle_xform': True,
-    'initial_header_level': 2,
+    'initial_header_level': 1,
     'report_level': 5,
     'syntax_highlight': 'none',
     'math_output': 'latex',


### PR DESCRIPTION
The initial_header_level, set to 2, causes 2 problems:

1. When including a TOC, it will have an empty first level, which just looks really bad.
2. It differs from the way headings are handled in MarkDown.