### PR TITLE
Tweak param signature for kbd role

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -230,8 +230,7 @@ class GitHubHTMLTranslator(HTMLTranslator):
         HTMLTranslator.depart_image(self, node)
 
 
-def kbd(name, rawtext, text, lineno, inliner, options=None, content=None):
-
+def kbd(name, rawtext, text, lineno, inliner, options={}, content=[]):
     return [nodes.raw('', '<kbd>%s</kbd>' % text, format='html')], []
 
 


### PR DESCRIPTION
Represent ``options`` is dict and ``content`` is list-like.  This is the same practice used in sphinx-doc/docutils.