### PR TITLE
Just use docutils instead of Sphinx

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.org](http://orgmode.org/) -- `gem install org-ruby`
 * [.creole](http://wikicreole.org/) -- `gem install creole`
 * [.mediawiki, .wiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth`
-* [.rst](http://docutils.sourceforge.net/rst.html) -- `python3 -m pip install sphinx`
+* [.rst](http://docutils.sourceforge.net/rst.html) -- `pip install docutils`
 * [.asciidoc, .adoc, .asc](http://asciidoc.org/) -- `gem install asciidoctor` (http://asciidoctor.org)
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::XHTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.


### PR DESCRIPTION
On installation guide for rST, package to use was changed in #940, which is not required.

Just use docutils with pip.