### PR TITLE
Update markdown.rb

### DIFF
--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -35,13 +35,10 @@ module GitHub
 
       def load
         return if @renderer
-        MARKDOWN_GEMS.each do |gem_name, renderer|
-          if try_require(gem_name)
-            @renderer = renderer
-            return
-          end
-        end
-        raise LoadError, "no suitable markdown gem found"
+        @renderer = proc { |content|
+          CommonMarker.render_html(content, :GITHUB_PRE_LANG, [:tagfilter, :autolink, :table, :strikethrough])
+        }
+        return
       end
 
       def render(filename, content)


### PR DESCRIPTION
How about something like this? I. e. I propose simply always use commonmarker. Just to show code readers that Github really uses commonmarker. (My patch is just example, in fact I don't know Ruby at all.)