### PR TITLE
github-markup: display basename instead of entire $0

### DIFF
--- a/bin/github-markup
+++ b/bin/github-markup
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.dirname(File.realpath(__FILE__)) + "/../lib"
 require 'github/markup'
 
 if ARGV.size < 1
-  print "usage: #$0 FILE [ FILES ... ]\n"
+  print "usage: #{File.basename($0)} FILE [ FILES ... ]\n"
   exit 1
 end
 


### PR DESCRIPTION
The `$0` in the usage text will be the full path when being executed via an rbenv shim, which leads to excessively long help text. For example, here's what the help text looks like for calling `github-markdown` with no arguments.

Before:

```
usage: /Users/mistydemeo/.rbenv/versions/2.4.2/bin/github-markup FILE [ FILES ... ]
```

After:

```
usage: github-markup FILE [ FILES ... ]
```