### PR TITLE
Perl POD with file variables line not marked up.

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -51,4 +51,4 @@ command(
   "restructuredtext"
 )
 
-command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod"], "pod")
+command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod", "Perl"], "pod")

--- a/test/fixtures/file-variables.sh
+++ b/test/fixtures/file-variables.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+t=1
 ./lib/github/commands/pod2html <( cat - <<EOF
 =pod
 
@@ -11,7 +12,8 @@ Test
 
 # -*- mode: perl; -*-
 EOF
-) | grep -q '<h1 id="NAME">' || { echo "not ok 1"; exit 1; } && { echo "ok 1"; }
+) | grep -q '<h1 id="NAME">' || { echo "not ok $t"; exit 1; } && { echo "ok $t"; }
+let t=($t + 1)
 
 ./lib/github/commands/pod2html <( cat - <<EOF
 #!/usr/bin/perl
@@ -25,4 +27,5 @@ Test
 
 =cut
 EOF
-) | grep -q '<h1 id="NAME">' || { echo "not ok 2"; exit 1; } && { echo "ok 2"; }
+) | grep -q '<h1 id="NAME">' || { echo "not ok $t"; exit 1; } && { echo "ok $t"; }
+let t=($t + 1)

--- a/test/fixtures/file-variables.sh
+++ b/test/fixtures/file-variables.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+./lib/github/commands/pod2html <( cat - <<EOF
+=pod
+
+=head1 NAME
+
+Test
+
+=cut
+
+# -*- mode: perl; -*-
+EOF
+) | grep -q '<h1 id="NAME">' || { echo "not ok 1"; exit 1; } && { echo "ok 1"; }
+
+./lib/github/commands/pod2html <( cat - <<EOF
+#!/usr/bin/perl
+# -*- mode: perl; -*-
+
+=pod
+
+=head1 NAME
+
+Test
+
+=cut
+EOF
+) | grep -q '<h1 id="NAME">' || { echo "not ok 2"; exit 1; } && { echo "ok 2"; }

--- a/test/markups/README.pod
+++ b/test/markups/README.pod
@@ -1,3 +1,4 @@
+# -*- mode: perl; -*-
 =head1 Matrixy
 
 =head2 INTRODUCTION


### PR DESCRIPTION
I was pointed here by @cmrberry for an issue I am having regarding POD markup.

When a Perl syntax file with POD contains a line specifying file variables for emacs
the whole file is returned verbatim.

On GitHub this appears thus:

* [Not Working](https://git.io/vbvXY)
* [Working](https://git.io/vbv1v)
* [Diff](https://git.io/vbv1q) - showing workaround as it's vs master

My workaround is to use the [alternate syntax](https://www.gnu.org/software/emacs/manual/html%5Fnode/emacs/Specifying-File-Variables.html#Specifying-File-Variables)

The change to `README.pod` should not cause the test to fail but does.

The shell script checks the behaviour of `lib/github/commands/pod2html` which 
appears to markup the POD correctly.

```
./test/fixtures/file-variables.sh 
ok 1
ok 2
```