### PR TITLE
Remove filesystem access

### DIFF
--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -40,10 +40,7 @@ module GitHub
       end
     end
 
-    def render(filename, content = nil, symlink = nil)
-      content ||= File.read(filename)
-      symlink = (File.symlink?(filename) rescue false) if symlink.nil?
-
+    def render(filename, content, symlink = false)
       if impl = renderer(filename, content, symlink)
         impl.render(filename, content)
       else


### PR DESCRIPTION
Reduce the security impact of using Markup; it doesn't need to access the filesystem.

This is a breaking change and needs a major version bump.

/cc @gregose 