### PR TITLE
Add pod6

### DIFF
--- a/lib/github/commands/pod62html
+++ b/lib/github/commands/pod62html
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+
+use Pod::To::HTML;
+
+sub MAIN()
+{
+  Pod::To::HTML.render(
+    $*IN.slurp,
+    default-title => 'Readme',
+  ).say;
+}

--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -16,6 +16,7 @@ module GitHub
     MARKUP_MEDIAWIKI = :mediawiki
     MARKUP_ORG = :org
     MARKUP_POD = :pod
+    MARKUP_POD6 = :pod6
     MARKUP_RDOC = :rdoc
     MARKUP_RST = :rst
     MARKUP_TEXTILE = :textile

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -52,3 +52,4 @@ command(
 )
 
 command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod"], "pod")
+command(::GitHub::Markups::MARKUP_POD6, :pod62html, /pod6/, ["Pod6"], "pod6")

--- a/test/markups/README.pod6
+++ b/test/markups/README.pod6
@@ -1,0 +1,27 @@
+=begin pod
+
+=TITLE Document Title
+
+=comment This is a comment
+
+=head1 First Section
+
+=item One
+=item Two
+
+Refer to L<Another section|#Another_Section>.
+
+=head1 Another Section
+
+NOTE: Here is some source code.
+
+    MAIN() {
+      say "Hello GitHub!"
+    }
+
+=item ☐ todo
+=item ☑ done
+
+content
+
+=end pod

--- a/test/markups/README.pod6
+++ b/test/markups/README.pod6
@@ -4,14 +4,14 @@
 
 =comment This is a comment
 
-=head1 First Section
+=head2 First Section
 
 =item One
 =item Two
 
 Refer to L<Another section|#Another_Section>.
 
-=head1 Another Section
+=head2 Another Section
 
 NOTE: Here is some source code.
 

--- a/test/markups/README.pod6.html
+++ b/test/markups/README.pod6.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Document Title</title>
+  <meta charset="UTF-8" />
+  <style>
+    /* code gets the browser-default font
+     * kbd gets a slightly less common monospace font
+     * samp gets the hard pixelly fonts
+     */
+    kbd { font-family: "Droid Sans Mono", "Luxi Mono", "Inconsolata", monospace }
+    samp { font-family: "Terminus", "Courier", "Lucida Console", monospace }
+    /* WHATWG HTML frowns on the use of <u> because it looks like a link,
+     * so we make it not look like one.
+     */
+    u { text-decoration: none }
+    .nested {
+        margin-left: 3em;
+    }
+    // footnote things:
+    aside, u { opacity: 0.7 }
+    a[id^="fn-"]:target { background: #ff0 }
+  </style>
+  <link rel="stylesheet" href="//design.perl6.org/perl.css">
+  
+  
+</head>
+<body class="pod">
+<div id="___top"></div>
+
+
+<h1 class='title'>Document Title</h1>
+<nav class="indexgroup">
+<table id="TOC">
+<caption><h2 id="TOC_Title">Table of Contents</h2></caption>
+  <tr class="toc-level-1"><td class="toc-number">1</td><td class="toc-text"><a href="#First_Section">First Section</a></td></tr>
+      <tr class="toc-level-1"><td class="toc-number">2</td><td class="toc-text"><a href="#Another_Section">Another Section</a></td></tr>
+     
+</table>
+</nav>
+
+<div class="pod-body
+
+">
+<h1 id="First_Section"><a class="u" href="#___top" title="go to top of document">First Section</a></h1>
+<ul><li><p>One</p>
+</li>
+<li><p>Two</p>
+</li>
+</ul>
+<p>Refer to <a href="#Another_Section">Another section</a>.</p>
+<h1 id="Another_Section"><a class="u" href="#___top" title="go to top of document">Another Section</a></h1>
+<p>NOTE: Here is some source code.</p>
+<pre class="pod-block-code">MAIN() {
+  say &quot;Hello GitHub!&quot;
+}</pre>
+<ul><li><p>☐ todo</p>
+</li>
+<li><p>☑ done</p>
+</li>
+</ul>
+<p>content</p>
+
+</div>
+
+
+</body>
+</html>
+

--- a/test/markups/README.pod6.html
+++ b/test/markups/README.pod6.html
@@ -33,8 +33,8 @@
 <nav class="indexgroup">
 <table id="TOC">
 <caption><h2 id="TOC_Title">Table of Contents</h2></caption>
-  <tr class="toc-level-1"><td class="toc-number">1</td><td class="toc-text"><a href="#First_Section">First Section</a></td></tr>
-      <tr class="toc-level-1"><td class="toc-number">2</td><td class="toc-text"><a href="#Another_Section">Another Section</a></td></tr>
+  <tr class="toc-level-2"><td class="toc-number">0.1</td><td class="toc-text"><a href="#First_Section">First Section</a></td></tr>
+      <tr class="toc-level-2"><td class="toc-number">0.2</td><td class="toc-text"><a href="#Another_Section">Another Section</a></td></tr>
      
 </table>
 </nav>
@@ -42,14 +42,14 @@
 <div class="pod-body
 
 ">
-<h1 id="First_Section"><a class="u" href="#___top" title="go to top of document">First Section</a></h1>
+<h2 id="First_Section"><a class="u" href="#___top" title="go to top of document">First Section</a></h2>
 <ul><li><p>One</p>
 </li>
 <li><p>Two</p>
 </li>
 </ul>
 <p>Refer to <a href="#Another_Section">Another section</a>.</p>
-<h1 id="Another_Section"><a class="u" href="#___top" title="go to top of document">Another Section</a></h1>
+<h2 id="Another_Section"><a class="u" href="#___top" title="go to top of document">Another Section</a></h2>
 <p>NOTE: Here is some source code.</p>
 <pre class="pod-block-code">MAIN() {
   say &quot;Hello GitHub!&quot;


### PR DESCRIPTION
I'm trying to make this work with [Perl 6 Pod](https://docs.perl6.org/language/pod#Code_blocks) in order to close https://github.com/perl6/doc/issues/167. I've [made a PR to Linguist](https://github.com/github/linguist) to make Linguist recognize `Pod6` as a language. This PR Works On My Machine™, though it probably needs some work to be production ready.

On this repository I've been having more troubles, though. For now, I've been running my tests with

```
ruby -I ../linguist/lib/ -I lib test/markup_test.rb 
```

and the Pod6 test keeps failing, even after I took the exact output from the `pod62html` command and put it into my test

```
./lib/github/commands/pod62html < test/markups/README.pod6 > test/markups/README.pod6.html
```

I'm at a slight loss here, and was hoping I could get some advice in here to get me going again.