### PR TITLE
POD: Create anchor for every =item directive

### DIFF
--- a/lib/github/commands/pod2html
+++ b/lib/github/commands/pod2html
@@ -7,6 +7,7 @@ my $p = Pod::Simple::XHTML->new;
 $p->html_header('');
 $p->html_footer('');
 $p->perldoc_url_prefix('https://metacpan.org/pod/');
+$p->anchor_items(1);
 $p->strip_verbatim_indent(sub {
     my $lines = shift;
     (my $indent = $lines->[0]) =~ s/\S.*//;


### PR DESCRIPTION
Setting anchor_items to true is needed for creating link to specific =item
directive. By default Pod::Simple::XHTML module does not enable it.

Webpage https://metacpan.org/ for POD documentation has it already enabled
and linking to =item directive is working fine.

Lot of POD documents already link to =item directives and without setting
anchor_items to true documents are semi-broken on GitHub.