### PR TITLE
don't render rmd as markdown

### DIFF
--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -29,7 +29,7 @@ module GitHub
 
       def initialize
         super(
-          /md|rmd|mkdn?|mdwn|mdown|markdown|litcoffee/i,
+          /md|mkdn?|mdwn|mdown|markdown|litcoffee/i,
           ["Markdown", "RMarkdown", "Literate CoffeeScript"])
       end
 

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -1,4 +1,4 @@
-# encoding: UTF-8
+# encoding: utf-8
 
 $LOAD_PATH.unshift File.dirname(__FILE__) + "/../lib"
 
@@ -78,8 +78,6 @@ message
   def test_knows_what_it_can_and_cannot_render
     assert_equal false, GitHub::Markup.can_render?('README.html', '<h1>Title</h1>')
     assert_equal true, GitHub::Markup.can_render?('README.markdown', '=== Title')
-    assert_equal true, GitHub::Markup.can_render?('README.rmd', '=== Title')
-    assert_equal true, GitHub::Markup.can_render?('README.Rmd', '=== Title')
     assert_equal false, GitHub::Markup.can_render?('README.cmd', 'echo 1')
     assert_equal true, GitHub::Markup.can_render?('README.litcoffee', 'Title')
   end

--- a/test/markups/README.rmd
+++ b/test/markups/README.rmd
@@ -1,3 +1,0 @@
-# Title
-* One
-* Two

--- a/test/markups/README.rmd.html
+++ b/test/markups/README.rmd.html
@@ -1,6 +1,0 @@
-<h1>Title</h1>
-
-<ul>
-<li>One</li>
-<li>Two</li>
-</ul>


### PR DESCRIPTION
Reverts #343 by user request -- R Markdown includes a lot of information that a regular Markdown renderer will omit, in such a way that there's no indication anything is missing.

/cc @yihui @karthik @jennybc 