### PR TITLE
Check whether filename is set when rendering asciidoc. Resolves #1289

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -33,13 +33,16 @@ markup(::GitHub::Markups::MARKUP_ASCIIDOC, :asciidoctor, /adoc|asc(iidoc)?/, ["A
     'idprefix' => '',
     'idseparator' => '-',
     'sectanchors' => nil,
-    'docname' => File.basename(filename, (extname = File.extname(filename))),
-    'docfilesuffix' => extname,
-    'outfilesuffix' => extname,
     'env' => 'github',
     'env-github' => '',
     'source-highlighter' => 'html-pipeline'
   }
+  if filename
+    attributes['docname']       = File.basename(filename, (extname = File.extname(filename)))
+    attributes['docfilesuffix'] = attributes['outfilesuffix'] = extname
+  else
+    attributes['outfilesuffix'] = '.adoc'
+  end
   Asciidoctor::Compliance.unique_id_start_index = 1
   Asciidoctor.convert(content, :safe => :secure, :attributes => attributes)
 end

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -94,7 +94,10 @@ message
   end
 
   def test_rendering_by_symbol
-    assert_equal '<p><code>test</code></p>', GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, '`test`').strip
+    markup = '`test`'
+    result = /<p><code>test<\/code><\/p>/
+    assert_match result, GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, markup).strip
+    assert_match result, GitHub::Markup.render_s(GitHub::Markups::MARKUP_ASCIIDOC, markup).split.join
   end
 
   def test_raises_error_if_command_exits_non_zero


### PR DESCRIPTION
I used @mojavelinux's snippet from issue #1289, but also added a test for good measure.