### PR TITLE
Improve contribution instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,7 @@ pkg/
 Gemfile.lock
 .project
 .buildpath
-*~ 
+*~
+.python-version
+.ruby-version
+vendor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,15 +25,24 @@ Anything else - [search open issues](https://github.com/github/markup/issues) or
 5. Open a [Pull Request][1]
 6. Enjoy a refreshing Diet Coke and wait
 
-**dependencies**
+**Dependencies**
+
+Markup requires Ruby 2.3.4 or later.
 
 You can run `script/bootstrap.contrib` to fetch them all.
 
+The bootstrap script requires `python2` to support `docutils` markup.
+
 ## Testing
 
-To run the tests:
+If you installed the dependencies using `gem install`, you can run the tests
+using:
 
     $ rake
+
+Or, if you installed using `bundle install`:
+
+    $ bundle exec rake
 
 If nothing complains, congratulations!
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.org](http://orgmode.org/) -- `gem install org-ruby` (https://github.com/wallyqs/org-ruby)
 * [.creole](http://wikicreole.org/) -- `gem install creole` (https://github.com/larsch/creole)
 * [.mediawiki, .wiki](http://www.mediawiki.org/wiki/Help:Formatting) -- `gem install wikicloth` (https://github.com/nricciar/wikicloth)
-* [.rst](http://docutils.sourceforge.net/rst.html) -- `pip install docutils`
+* [.rst](http://docutils.sourceforge.net/rst.html) -- `pip install docutils` (**Python 2** is required)
 * [.asciidoc, .adoc, .asc](http://asciidoc.org/) -- `gem install asciidoctor` (http://asciidoctor.org)
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::XHTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,4 +5,4 @@ set -e
 cd $(dirname "$0")/..
 
 bundle install
-easy_install docutils
+pip install docutils

--- a/script/bootstrap.contrib
+++ b/script/bootstrap.contrib
@@ -5,8 +5,8 @@ set -e
 cd $(dirname "$0")/..
 
 bundle install --path vendor/bundle
-virtualenv vendor/python && source vendor/python/bin/activate
-pip install docutils
+python2 -m virtualenv vendor/python && source vendor/python/bin/activate
+python2 -m pip install docutils
 
 echo ""
 echo "*** DONE ***"

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,7 @@ export RUBY_HEAP_SLOTS_INCREMENT=400000
 export RUBY_HEAP_SLOTS_GROWTH_FACTOR=1
 
 export PATH="/usr/share/rbenv/shims:$PATH"
-export RBENV_VERSION="1.9.3"
+export RBENV_VERSION="2.4.1"
 
 # bootstrap gem environment changes
 echo "Bootstrapping gem environment ..."


### PR DESCRIPTION
The contribution instructions were missing some details that were necessary to get the test suite working:

* Explicitly stating that Python 2 is required
* Clarifying that `rake` by itself isn't sufficient if you use the `bundle install` option for installing dependencies.
* No Ruby version is specified anywhere in the docs; the only versions that are mentioned are an unsupported version in the CI build script.