### PR TITLE
Update Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ dist: trusty
 sudo: required
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.3.8
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
 notifications:
   email: false
 git:


### PR DESCRIPTION
CI is currently failing because of the use of some old, unsupported Ruby versions. 

This change adds the most recent point release for each minor version of Ruby that is still supported, as well as the 2.3 branch (which still works).