### PR TITLE
Add Rakudoc (aka POD6) markup language for Raku (formerly Perl 6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ dist: trusty
 sudo: required
 language: ruby
 rvm:
-  - 2.1.10
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.3.8
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
 notifications:
   email: false
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install perl rakudo-pkg
   - export PATH=$PATH:/.perl6/bin:/opt/rakudo-pkg/bin
+  - export NVM_DIR=/usr/local/nvm
+  - export NODE_VERSION=12.16.1
+  - sudo mkdir -p $NVM_DIR
+  - sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+  - export PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+  - sudo npm install -g pod6@0.0.20
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
   - sudo pip install docutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - sudo mkdir -p $NVM_DIR
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | sudo bash
   - export PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-  - sudo env PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH npm install -g pod6@0.0.20
+  - sudo env PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH npm install -g pod6@0.0.24
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
   - sudo pip install docutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - export NVM_DIR=/usr/local/nvm
   - export NODE_VERSION=12.16.1
   - sudo mkdir -p $NVM_DIR
-  - sudo curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+  - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | sudo bash
   - export PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
   - sudo npm install -g pod6@0.0.20
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - sudo mkdir -p $NVM_DIR
   - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | sudo bash
   - export PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-  - sudo npm install -g pod6@0.0.20
+  - sudo env PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH npm install -g pod6@0.0.20
   - curl -L http://cpanmin.us | perl - --sudo App::cpanminus
   - sudo cpanm --installdeps --notest Pod::Simple
   - sudo pip install docutils

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p $NVM_DIR
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
 
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-RUN npm install -g pod6@0.0.20
+RUN npm install -g pod6@0.0.24
 
 
 ENV PATH $PATH:/opt/rakudo-pkg/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,24 @@ RUN apt-get update -qq
 RUN apt-get install -y \
     perl rakudo-pkg curl git build-essential python python-pip \
     libssl-dev libreadline-dev zlib1g-dev \
-    libicu-dev cmake pkg-config
+    libicu-dev cmake3 pkg-config
+
+
+#####################################
+# npm, nvm & yarn:
+#####################################
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+# latest LTS version
+ENV NODE_VERSION 12.16.1
+# node
+RUN mkdir -p $NVM_DIR
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+RUN npm install -g pod6@0.0.20
+
 
 ENV PATH $PATH:/opt/rakudo-pkg/bin
 RUN install-zef-as-user && zef install Pod::To::HTML

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ you wish to run the library. You can also run `script/bootstrap` to fetch them a
 * [.asciidoc, .adoc, .asc](http://asciidoc.org/) -- `gem install asciidoctor` (http://asciidoctor.org)
 * [.pod](http://search.cpan.org/dist/perl/pod/perlpod.pod) -- `Pod::Simple::XHTML`
   comes with Perl >= 5.10. Lower versions should install Pod::Simple from CPAN.
+* [.pod6, .rakudoc](https://docs.raku.org/language/pod) -- `npm install pod6` (https://github.com/zag/js-pod6)
 
 Installation
 -----------

--- a/github-markup.gemspec
+++ b/github-markup.gemspec
@@ -4,10 +4,8 @@ Gem::Specification.new do |s|
   s.name          = "github-markup"
   s.version       = GitHub::Markup::VERSION
   s.summary       = "The code GitHub uses to render README.markup"
-  s.description   = <<~DESC
-    This gem is used by GitHub to render any fancy markup such as Markdown,
-    Textile, Org-Mode, etc. Fork it and add your own!
-  DESC
+  s.description   = "This gem is used by GitHub to render any fancy markup such as Markdown," +
+                    "Textile, Org-Mode, etc. Fork it and add your own!
   s.authors       = ["Chris Wanstrath"]
   s.email         = "chris@ozmm.org"
   s.homepage      = "https://github.com/github/markup"

--- a/github-markup.gemspec
+++ b/github-markup.gemspec
@@ -4,8 +4,10 @@ Gem::Specification.new do |s|
   s.name          = "github-markup"
   s.version       = GitHub::Markup::VERSION
   s.summary       = "The code GitHub uses to render README.markup"
-  s.description   = "This gem is used by GitHub to render any fancy markup such as Markdown," +
-                    "Textile, Org-Mode, etc. Fork it and add your own!
+  s.description   = <<~DESC
+    This gem is used by GitHub to render any fancy markup such as Markdown,
+    Textile, Org-Mode, etc. Fork it and add your own!
+  DESC
   s.authors       = ["Chris Wanstrath"]
   s.email         = "chris@ozmm.org"
   s.homepage      = "https://github.com/github/markup"

--- a/lib/github/commands/pod6html
+++ b/lib/github/commands/pod6html
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec pod6html "$@"

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -55,5 +55,5 @@ command(
   "restructuredtext"
 )
 
-command(::GitHub::Markups::MARKUP_POD6, :pod6html, /pod6/, ["Pod 6"], "pod6")
+command(::GitHub::Markups::MARKUP_POD6, :pod6html, /pod6|rakudoc/, ["Pod 6"], "pod6")
 command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod"], "pod")

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -55,5 +55,5 @@ command(
   "restructuredtext"
 )
 
-command(::GitHub::Markups::MARKUP_POD6, :pod62html, /pod6/, ["Pod 6"], "pod6")
+command(::GitHub::Markups::MARKUP_POD6, :pod6html, /pod6/, ["Rakudoc"], "pod6")
 command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod"], "pod")

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -55,5 +55,5 @@ command(
   "restructuredtext"
 )
 
-command(::GitHub::Markups::MARKUP_POD6, :pod6html, /pod6/, ["Rakudoc"], "pod6")
+command(::GitHub::Markups::MARKUP_POD6, :pod6html, /pod6/, ["Pod 6"], "pod6")
 command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod"], "pod")

--- a/test/markups/README.pod6
+++ b/test/markups/README.pod6
@@ -1,0 +1,53 @@
+=begin pod
+=head1 Title
+=head2 Subtitle
+      
+=for code :allow(B)
+This I<is> a B<text>
+
+  =alias PROGNAME    Earl Irradiatem Evermore
+  =alias VENDOR      4D Kingdoms
+  =alias TERMS_URLS  =item L<http://www.4dk.com/eie>
+  =                  =item L<http://www.4dk.co.uk/eie.io/>
+  =                  =item L<http://www.fordecay.ch/canttouchthis>
+  
+  The use of A<PROGNAME> is U<subject> to the terms and conditions
+  laid out by A<VENDOR>, as specified at:
+  
+       A<TERMS_URLS>
+
+=para
+Use a C<for> loop instead.N<The Raku C<for> loop is far more
+powerful than its Perl 5 predecessor.> Preferably with an explicit
+iterator variable.
+
+Options B<are>:
+
+=item1  Animal
+=item2     Vertebrate
+=item2     Invertebrate
+
+=item1  Phase
+=item2     Solid
+=item2     Liquid
+=item2     Gas
+=item2     I<Chocolate>
+
+I<Table>
+
+=begin table :caption('Super table!')
+                        Secret
+        Superhero       Identity          Superpower
+        =============   ===============   ===================
+        The Shoveller   Eddie Stevens     King Arthur's
+                                          singing shovel
+
+        Blue Raja       Geoffrey Smith    Master of cutlery
+
+        Mr Furious      Roy Orson         Ticking time bomb
+                                          of fury
+
+        The Bowler      Carol Pinnsler    Haunted bowling ball
+
+=end table
+=end pod

--- a/test/markups/README.pod6.html
+++ b/test/markups/README.pod6.html
@@ -1,0 +1,20 @@
+<h1>Title
+</h1><h2>Subtitle
+</h2><pre><code>This I&lt;is&gt; a <strong>text</strong>
+</code></pre><pre><code>The use of A&lt;PROGNAME&gt; is U&lt;subject&gt; to the terms and conditions
+  laid out by A&lt;VENDOR&gt;, as specified at:
+</code></pre><pre><code>A&lt;TERMS_URLS&gt;
+</code></pre><p>Use a <code>for</code> loop instead.<sup id="fnref:1" class="footnote"><a href="#fn:1">[1]</a></sup> Preferably with an explicit
+iterator variable.
+</p><p>Options <strong>are</strong>:
+</p><ul><li><p>Animal
+</p></li><ul><li><p>Vertebrate
+</p></li><li><p>Invertebrate
+</p></li></ul><li><p>Phase
+</p></li><ul><li><p>Solid
+</p></li><li><p>Liquid
+</p></li><li><p>Gas
+</p></li><li><p><em>Chocolate</em>
+</p></li></ul></ul><p><em>Table</em>
+</p><table><caption>Super table!</caption><tr><th>               Superhero    </th><th> Secret Identity      </th><th>  Superpower</th></tr><tr><td> The Shoveller              </td><td> Eddie Stevens                </td><td> King Arthur&#x27;s singing shovel</td></tr><tr><td> Blue Raja    </td><td> Geoffrey Smith</td><td> Master of cutlery</td></tr><tr><td> Mr Furious                 </td><td> Roy Orson                    </td><td> Ticking time bomb of fury</td></tr><tr><td> The Bowler   </td><td> Carol Pinnsler</td><td> Haunted bowling ball</td></tr></table><div class="footnotes"><p><sup id="fn:1" class="footnote"><a href="#fnref:1">[1]</a></sup> The Raku <code>for</code> loop is far more
+powerful than its Perl 5 predecessor.</p></div>

--- a/test/markups/README.pod6.html
+++ b/test/markups/README.pod6.html
@@ -4,17 +4,55 @@
 </code></pre><pre><code>The use of A&lt;PROGNAME&gt; is U&lt;subject&gt; to the terms and conditions
   laid out by A&lt;VENDOR&gt;, as specified at:
 </code></pre><pre><code>A&lt;TERMS_URLS&gt;
-</code></pre><p>Use a <code>for</code> loop instead.<sup id="fnref:1" class="footnote"><a href="#fn:1">[1]</a></sup> Preferably with an explicit
+</code></pre><p>Use a <code>for</code> loop instead.<sup><a href="#fn:1">[1]</a></sup> Preferably with an explicit
 iterator variable.
 </p><p>Options <strong>are</strong>:
-</p><ul><li><p>Animal
-</p></li><ul><li><p>Vertebrate
-</p></li><li><p>Invertebrate
-</p></li></ul><li><p>Phase
-</p></li><ul><li><p>Solid
-</p></li><li><p>Liquid
-</p></li><li><p>Gas
-</p></li><li><p><em>Chocolate</em>
-</p></li></ul></ul><p><em>Table</em>
-</p><table><caption>Super table!</caption><tr><th>               Superhero    </th><th> Secret Identity      </th><th>  Superpower</th></tr><tr><td> The Shoveller              </td><td> Eddie Stevens                </td><td> King Arthur&#x27;s singing shovel</td></tr><tr><td> Blue Raja    </td><td> Geoffrey Smith</td><td> Master of cutlery</td></tr><tr><td> Mr Furious                 </td><td> Roy Orson                    </td><td> Ticking time bomb of fury</td></tr><tr><td> The Bowler   </td><td> Carol Pinnsler</td><td> Haunted bowling ball</td></tr></table><div class="footnotes"><p><sup id="fn:1" class="footnote"><a href="#fnref:1">[1]</a></sup> The Raku <code>for</code> loop is far more
+</p><ul>
+<li><p>Animal
+</p></li>
+<ul>
+<li><p>Vertebrate
+</p></li>
+<li><p>Invertebrate
+</p></li>
+</ul>
+<li><p>Phase
+</p></li>
+<ul>
+<li><p>Solid
+</p></li>
+<li><p>Liquid
+</p></li>
+<li><p>Gas
+</p></li>
+<li><p><em>Chocolate</em>
+</p></li>
+</ul>
+</ul><p><em>Table</em>
+</p><table>Super table!<tr>
+<th>               Superhero    </th>
+<th> Secret Identity      </th>
+<th>  Superpower</th>
+</tr>
+<tr>
+<td> The Shoveller              </td>
+<td> Eddie Stevens                </td>
+<td> King Arthur's singing shovel</td>
+</tr>
+<tr>
+<td> Blue Raja    </td>
+<td> Geoffrey Smith</td>
+<td> Master of cutlery</td>
+</tr>
+<tr>
+<td> Mr Furious                 </td>
+<td> Roy Orson                    </td>
+<td> Ticking time bomb of fury</td>
+</tr>
+<tr>
+<td> The Bowler   </td>
+<td> Carol Pinnsler</td>
+<td> Haunted bowling ball</td>
+</tr>
+</table><div><p><sup><a href="#fnref:1">[1]</a></sup> The Raku <code>for</code> loop is far more
 powerful than its Perl 5 predecessor.</p></div>


### PR DESCRIPTION
Hi 👋!
There have been previous attempts [1][2] to add pod6 support.
However, due security reasons [3], they are was rejected.
This implementation in JavaScript and does not launch any code.
The source code is located here: https://github.com/zag/js-pod6
thank you!
with best,
Alex

[1] Perl 6 Pod Rendering. https://github.com/github/markup/issues/907
[2] POD6 not actually supported. https://github.com/github/markup/issues/1260
[3] by @kivikakk in https://github.com/github/markup/issues/1260#issuecomment-466825090_
