### PR TITLE
Run rest2html with python to allow use of Python 3

### DIFF
--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -49,7 +49,7 @@ end
 
 command(
   ::GitHub::Markups::MARKUP_RST,
-  "python2 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
+  "python -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
   /re?st(\.txt)?/,
   ["reStructuredText"],
   "restructuredtext"


### PR DESCRIPTION
Call `rest2html` with `python` (instead of `python2`) to allow use of Python 3. Python 2 is EOL, so this change would make it possible to use Python 3 here.