### PR TITLE
fix unknown directive options removing the directive entirely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: push
+on: [push, pull_request]
 
 env:
   JRUBY_OPTS: -Xcext.enabled=true

--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -47,7 +47,7 @@ except:
 import codecs
 import io
 
-from docutils import nodes
+from docutils import nodes, utils
 from docutils.parsers.rst import directives, roles
 from docutils.parsers.rst.directives.body import CodeBlock, Directive
 from docutils.core import publish_parts
@@ -75,6 +75,35 @@ from docutils import nodes
 
 original_behavior = False  # Documents original docutils behavior
 github_display = True
+
+def extract_extension_options(field_list, option_spec):
+    """
+    Overrides `utils.extract_extension_options` and inlines
+    `utils.assemble_option_dict` to make it ignore unknown options passed to
+    directives (i.e. ``:caption:`` for ``.. code-block:``).
+    """
+
+    dropped = set()
+    options = {}
+    for name, value in utils.extract_options(field_list):
+        convertor = option_spec.get(name)
+        if name in options or name in dropped:
+            raise utils.DuplicateOptionError('duplicate option "%s"' % name)
+
+        # silently drop unknown options as long as they are not duplicates
+        if convertor is None:
+            dropped.add(name)
+            continue
+
+        # continue as before
+        try:
+            options[name] = convertor(value)
+        except (ValueError, TypeError) as detail:
+            raise detail.__class__('(option: "%s"; value: %r)\n%s'
+                                   % (name, value, ' '.join(detail.args)))
+    return options
+
+utils.extract_extension_options = extract_extension_options
 
 def unknown_directive(self, type_name):
     lineno = self.state_machine.abs_line_number()

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -39,6 +39,12 @@ The UTF-8 quote character in this table used to cause python to go boom. Now doc
 
 	python.code('hooray')
 
+.. code:: python
+	:caption: An ignored Sphinx option
+	:made-up-option: An ignored made up option
+
+	python.code('hello world')
+
 .. doctest:: ignored
 
 	>>> some_function()

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -64,6 +64,9 @@ A block of code
 python.code('hooray')
 </pre>
 <pre lang="python">
+python.code('hello world')
+</pre>
+<pre lang="python">
 &gt;&gt;&gt; some_function()
 'result'
 </pre>


### PR DESCRIPTION
Fixes the following:

```rst
.. code:: python
	:caption: An ignored Sphinx option

	python.code('hello world')
```