### PR TITLE
Render RST using python3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 4.0.0 - 2021-03-31
+
+* Drop support for Python 2 in RST rendering [#1456](https://github.com/github/markup/pull/1456)
+
 ## 3.0.5 - 2020-11-12
 
 * Add commonmarker_exts to commonmarker options [#1268](https://github.com/github/markup/pull/1268)
@@ -72,8 +76,8 @@
 
 ### Added
 
-* Re-introduce [#537](https://github.com/github/markup/pull/537) to detect language of markup document  
-  However `github-linguist` is optional and this gem will fallback to extensions for detection.  
+* Re-introduce [#537](https://github.com/github/markup/pull/537) to detect language of markup document
+  However `github-linguist` is optional and this gem will fallback to extensions for detection.
 
 [Full changelog](https://github.com/github/markup/compare/v1.4.9...v1.5.0)
 

--- a/lib/github-markup.rb
+++ b/lib/github-markup.rb
@@ -1,6 +1,6 @@
 module GitHub
   module Markup
-    VERSION = '3.0.5'
+    VERSION = '4.0.0'
     Version = VERSION
   end
 end

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -49,7 +49,7 @@ end
 
 command(
   ::GitHub::Markups::MARKUP_RST,
-  "python2 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
+  "python3 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
   /re?st(\.txt)?/,
   ["reStructuredText"],
   "restructuredtext"

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -49,7 +49,7 @@ end
 
 command(
   ::GitHub::Markups::MARKUP_RST,
-  "python3 -S #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
+  "python3 #{Shellwords.escape(File.dirname(__FILE__))}/commands/rest2html",
   /re?st(\.txt)?/,
   ["reStructuredText"],
   "restructuredtext"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,4 +5,4 @@ set -e
 cd $(dirname "$0")/..
 
 bundle install
-easy_install docutils
+pip3 install docutils

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -16,6 +16,47 @@
 <li>Somé UTF-8°</li>
 </ol>
 <p>The UTF-8 quote character in this table used to cause python to go boom. Now docutils just silently ignores it.</p>
+<table>
+Things that are Awesome (on a scale of 1-11)
+
+
+
+
+<tbody valign="top">
+<tr>
+<td>Thing</td>
+<td>Awesomeness</td>
+</tr>
+<tr>
+<td>Icecream</td>
+<td>7</td>
+</tr>
+<tr>
+<td>Honey Badgers</td>
+<td>10.5</td>
+</tr>
+<tr>
+<td>Nickelback</td>
+<td>-2</td>
+</tr>
+<tr>
+<td>Iron Man</td>
+<td>10</td>
+</tr>
+<tr>
+<td>Iron Man 2</td>
+<td>3</td>
+</tr>
+<tr>
+<td>Tabular Data</td>
+<td>5</td>
+</tr>
+<tr>
+<td>Made up ratings</td>
+<td>11</td>
+</tr>
+</tbody>
+</table>
 <pre>
 A block of code
 </pre>


### PR DESCRIPTION
#919 added support for python3, but we were still explicitly [shelling out to the `python2` executable](https://github.com/github/markup/blob/194e363c2a2cd44caa8e799a5ef4e64fb2824f0c/lib/github/markups.rb#L52) here.  Let's switch that to python3 since python2 is EOL.

This bumps the major version because it's a breaking change for anyone running in an environment with only python2.

Unfortunately it looks like CI is not passing because the travis config is quite outdated.  The root cause of the failures appears to be at-least-two-fold:
 - the matrix of ruby versions is out of date
 - the travis config [relies](https://github.com/github/markup/blob/master/.travis.yml#L15) on [bintray](https://bintray.com/) which is about to be shut down and appears to be no longer working.

I attempted to fix travis but I think a better fix is just to switch to Actions, e.g. https://github.com/github/markup/pull/1453.