### PR TITLE
spelling: exclude

### DIFF
--- a/test/markups/README.org
+++ b/test/markups/README.org
@@ -58,7 +58,7 @@ end
      - Skipping text before the first headline (option skip:t)
      - Skipping tables (option |:nil)
      - Custom todo keywords
-     - EXPORT_SELECT_TAGS and EXPORT_EXLUDE_TAGS for controlling parts of
+     - EXPORT_SELECT_TAGS and EXPORT_EXCLUDE_TAGS for controlling parts of
        the tree to export
    - Rewrite "file:(blah).org" links to "http:(blah).html" links. This
      makes the inter-links to other org-mode files work.

--- a/test/markups/README.org.html
+++ b/test/markups/README.org.html
@@ -52,7 +52,7 @@ end
       <li>Skipping text before the first headline (option skip:t)</li>
       <li>Skipping tables (option |:nil)</li>
       <li>Custom todo keywords</li>
-      <li>EXPORT_SELECT_TAGS and EXPORT_EXLUDE_TAGS for controlling parts of
+      <li>EXPORT_SELECT_TAGS and EXPORT_EXCLUDE_TAGS for controlling parts of
         the tree to export</li>
     </ul>
   </li>


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/markup/commit/e2feaf47e4213f33b3d1690bfea1c03e5e3ea141#commitcomment-51803670

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/markup/commit/fe209420b3b74b44199c6762a121636c322fcea0

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

Fwiw, this is an iteration beyond the tooling from #1128 