### PR TITLE
Make sure all anchors are created for RST links

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -199,8 +199,8 @@ class GitHubHTMLTranslator(HTMLTranslator):
     # see also: http://bit.ly/NHtyRx
     # the a is to support ::contents with ::sectnums: http://git.io/N1yC
     def visit_section(self, node):
-        id_attribute = node.attributes['ids'][0]
-        self.body.append('<a name="%s"></a>\n' % id_attribute)
+        for id_attribute in node.attributes['ids']:
+            self.body.append('<a name="%s"></a>\n' % id_attribute)
         self.section_level += 1
 
     def depart_section(self, node):

--- a/test/markups/README.rst
+++ b/test/markups/README.rst
@@ -8,6 +8,8 @@ Example text.
 
 .. contents:: Table of Contents
 
+.. _label_for_header_2:
+
 Header 2
 --------
 
@@ -16,6 +18,8 @@ Header 2
 2. More ``code``, hooray
 
 3. Somé UTF-8°
+
+4. `Link to the above header <label_for_header_2_>`_
 
 The UTF-8 quote character in this table used to cause python to go boom. Now docutils just silently ignores it.
 

--- a/test/markups/README.rst.html
+++ b/test/markups/README.rst.html
@@ -9,11 +9,13 @@
 </ul>
 </div>
 <a name="header-2"></a>
+<a name="label-for-header-2"></a>
 <h2><a href="#toc-entry-1">Header 2</a></h2>
 <ol>
 <li>Blah blah <code>code</code> blah</li>
 <li>More <code>code</code>, hooray</li>
 <li>Somé UTF-8°</li>
+<li><a href="#label-for-header-2">Link to the above header</a></li>
 </ol>
 <p>The UTF-8 quote character in this table used to cause python to go boom. Now docutils just silently ignores it.</p>
 <table>


### PR DESCRIPTION
Fixes #1535.

Running the script on the source of https://gist.github.com/felixfontein/5ec5ad555ba6cdb293beb04c83280c90 produces:
```.html
<a name="test-section"></a>
<h2>Test section</h2>
<p>Link: <a class="reference internal" href="#target">link to target</a>.</p>
<a name="target-section"></a>
<a name="target"></a>
<h2>Target section</h2>
<p>The link should point to this section's title.</p>
```
Here both expected anchors (the auto-generated one from the section title, and the one from the label) are created.