### PR TITLE
Add support for kramdown options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem "posix-spawn", :platforms => :ruby
 gem "redcarpet", :platforms => :ruby
-gem "kramdown", :platforms => :jruby
+gem "kramdown"
 gem "RedCloth"
 # using a tag version here because 0.18.3 was not published by the author to encourage users to upgrade.
 # however we want to bump up to this version since this has a security patch

--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -22,7 +22,6 @@ module GitHub
           Maruku.new(content).to_html
         },
         "kramdown" => proc { |content, options: {}|
-          puts options.inspect
           Kramdown::Document.new(content, options.fetch(:kramdown_opts, {})).to_html
         },
         "bluecloth" => proc { |content, options: {}|

--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -22,7 +22,8 @@ module GitHub
           Maruku.new(content).to_html
         },
         "kramdown" => proc { |content, options: {}|
-          Kramdown::Document.new(content).to_html
+          puts options.inspect
+          Kramdown::Document.new(content, options.fetch(:kramdown_opts, {})).to_html
         },
         "bluecloth" => proc { |content, options: {}|
           BlueCloth.new(content).to_html

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -8,6 +8,8 @@ require 'html/pipeline'
 require 'nokogiri'
 require 'nokogiri/diff'
 
+require 'kramdown'
+
 def normalize_html(text)
   text.strip
       .gsub(/\s\s+/,' ')
@@ -116,7 +118,14 @@ message
     content = "Noël"
     assert_equal content.encoding.name, GitHub::Markup.render('Foo.rst', content).encoding.name
   end
-
+  
+  def test_kramdown_options
+    content = "# Test\n"
+    kramdown_implementation = GitHub::Markup::Markdown::MARKDOWN_GEMS['kramdown'] 
+    assert_equal "<h1 id=\"test\">Test</h1>\n", kramdown_implementation.call(content)
+    assert_equal "<h1>Test</h1>\n", kramdown_implementation.call(content, options: {:kramdown_opts => { :auto_ids=>false}})
+  end
+  
   def test_commonmarker_options
     assert_equal "<p>hello <!-- raw HTML omitted --> world</p>\n", GitHub::Markup.render("test.md", "hello <bad> world")
     assert_equal "<p>hello <bad> world</p>\n", GitHub::Markup.render("test.md", "hello <bad> world", options: {commonmarker_opts: [:UNSAFE]})
@@ -130,4 +139,5 @@ message
     assert_equal "&lt;style>.red{color: red;}&lt;/style>\n", GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, "<style>.red{color: red;}</style>", options: {commonmarker_opts: [:UNSAFE]})
     assert_equal "<style>.red{color: red;}</style>\n", GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, "<style>.red{color: red;}</style>", options: {commonmarker_opts: [:UNSAFE], commonmarker_exts: [:autolink, :table, :strikethrough]})
   end
+  
 end


### PR DESCRIPTION
For `commonmarker`, it is already possible to pass in parsing and rendering options in the `GitHub::Markup.render` call, e.g.:

```ruby
GitHub::Markup.render("test.md", "hello <bad> world", options: {commonmarker_opts: [:UNSAFE]})
```

This PR adds support for the same feature for the `kramdown` implementation, allowing e.g.:

```ruby
GitHub::Markup.render("# Test\n", options: {:kramdown_opts => { :auto_ids=>false}})
```

I've also added tests, which necessitated requiring `kramdown` on both the JRuby and MRI platforms (instead of just JRuby). If this is undesirable, the tests could also be left out by reverting the last commit from this PR.