### PR TITLE
Remove reference to deprecated support email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ This library's only job is to decide which markup format to use and call out to 
 If you are having an issue with:
 
 * **Syntax highlighting** - see [github/linguist](https://github.com/github/linguist/blob/master/CONTRIBUTING.md#fixing-syntax-highlighting)
-* **Markdown on GitHub** - contact support@github.com
+* **Markdown on GitHub** - contact [GitHub Support](https://support.github.com/)
 * **Styling issues on GitHub** - see [primer-markdown](https://github.com/primer/primer-css/tree/master/modules/primer-markdown) module in the [primer/primer-css](https://github.com/primer/primer-css) repository
 
 Anything else - [search open issues](https://github.com/github/markup/issues) or create an issue and and we'll help point you in the right direction.


### PR DESCRIPTION
Support should be initiated via the Support Portal.