### PR TITLE
Add markdown support for .mdx files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 4.0.2 - 2023-10-10
+* Add support for .mdx files in markdown
+
 ## 4.0.1 - 2022-03-07
 * Update to commonmarker 0.18.3; There isn't a version on RubyGems for this, so this is pointing to a [tag version on GitHub](https://github.com/gjtorikian/commonmarker/blob/v0.18.3/commonmarker.gemspec)
 

--- a/lib/github-markup.rb
+++ b/lib/github-markup.rb
@@ -1,6 +1,6 @@
 module GitHub
   module Markup
-    VERSION = '4.0.1'
+    VERSION = '4.0.2'
     Version = VERSION
   end
 end

--- a/lib/github/markup/markdown.rb
+++ b/lib/github/markup/markdown.rb
@@ -31,8 +31,8 @@ module GitHub
 
       def initialize
         super(
-          /md|mkdn?|mdwn|mdown|markdown|litcoffee/i,
-          ["Markdown", "Literate CoffeeScript"])
+          /md|mkdn?|mdwn|mdown|markdown|mdx|litcoffee/i,
+          ["Markdown", "MDX", "Literate CoffeeScript"])
       end
 
       def load


### PR DESCRIPTION
Implements https://github.com/github/repos/issues/8873

Adds basic support for rendering .mdx files as markdown. Non-markdown syntax will just be printed out as plain text