### PR TITLE
POD: fix the handling of UTF-8 encoded documents

### DIFF
--- a/lib/github/commands/pod2html
+++ b/lib/github/commands/pod2html
@@ -3,6 +3,8 @@
 use strict;
 use Pod::Simple::XHTML 3.11;
 
+STDOUT->binmode(':encoding(UTF-8)');
+
 my $p = Pod::Simple::XHTML->new;
 $p->html_header('');
 $p->html_footer('');


### PR DESCRIPTION
Pod::Simple outputs characters, not bytes, so STDOUT needs an encoding layer.

Example Pod document where UTF-8 wasn't rendered properly:

https://github.com/Perl/perl5/blob/23e1e448eede42df229448fd610799a7a0831254/Porting/release_schedule.pod