### PR TITLE
Update activesupport to 7.1.3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 .buildpath
 *~
 vendor/
+.DS_Store

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+## 5.0.1 - 2024-06-17
+* Bump activesupport from 4.0 to 7.1.3.4
+
 ## 5.0.0 - 2024-06-17
 * Drop support for Ruby versions < 3
 * Bump nokogiri from 1.8.1 to 1.16.5

--- a/github-markup.gemspec
+++ b/github-markup.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   s.add_development_dependency 'rake', '~> 12'
-  s.add_development_dependency 'activesupport', '~> 4.0'
+  s.add_development_dependency 'activesupport', '~> 7.1.3.4'
   s.add_development_dependency 'minitest', '~> 5.4', '>= 5.4.3'
   s.add_development_dependency 'html-pipeline', '~> 1.0'
   s.add_development_dependency 'sanitize', '>= 4.6.3'

--- a/lib/github-markup.rb
+++ b/lib/github-markup.rb
@@ -1,6 +1,6 @@
 module GitHub
   module Markup
-    VERSION = '5.0.0'
+    VERSION = '5.0.1'
     Version = VERSION
   end
 end


### PR DESCRIPTION
Updates the activesupport dependency in the `github-markup.gemspec` file to version `7.1.3.4`