### PR TITLE
chore: add dependabot and update github actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,39 @@
+---
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore(deps)'
+    groups:
+      dependencies:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,21 +19,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
           fetch-depth: 10
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@ff740bc00a01b3a50fffc55a1071b1060eeae9dc # v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
           # This should match lib/github/markups.rb GitHub::Markups::MARKUP_RST
           python-version: '3.x'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
 pkg/
 .bundle
-Gemfile.lock
 .project
 .buildpath
 *~

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,135 @@
+GIT
+  remote: https://github.com/gjtorikian/commonmarker.git
+  revision: 2838ebaa83ee0081d481c21f3bc0e4cb3e8de9da
+  tag: v0.18.3
+  specs:
+    commonmarker (0.18.3)
+      ruby-enum (~> 0.5)
+
+PATH
+  remote: .
+  specs:
+    github-markup (5.0.1)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    RedCloth (4.3.4)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    asciidoctor (2.0.23)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    builder (3.3.0)
+    cgi (0.4.1)
+    charlock_holmes (0.7.7)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    crass (1.0.6)
+    creole (0.3.8)
+    drb (2.2.1)
+    expression_parser (0.9.0)
+    github-linguist (7.30.0)
+      cgi
+      charlock_holmes (~> 0.7.7)
+      mini_mime (~> 1.0)
+      rugged (~> 1.0)
+    html-pipeline (1.11.0)
+      activesupport (>= 2)
+      nokogiri (~> 1.4)
+    htmlentities (4.3.4)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    mini_mime (1.1.5)
+    minitest (5.23.1)
+    mutex_m (0.2.0)
+    nokogiri (1.16.6-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-linux)
+      racc (~> 1.4)
+    nokogiri-diff (0.3.0)
+      nokogiri (~> 1.5)
+      tdiff (~> 0.4)
+    org-ruby (0.9.9)
+      rubypants (~> 0.2)
+    psych (5.1.2)
+      stringio
+    racc (1.8.0)
+    rake (13.2.1)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
+    redcarpet (3.6.0)
+    rexml (3.3.0)
+      strscan
+    ruby-enum (0.9.0)
+      i18n
+    rubypants (0.7.1)
+    rugged (1.7.2)
+    sanitize (6.1.1)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    stringio (3.1.1)
+    strscan (3.1.0)
+    tdiff (0.4.0)
+    twitter-text (1.14.7)
+      unf (~> 0.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.9.1)
+    wikicloth (0.8.3)
+      builder
+      expression_parser
+      htmlentities
+      nokogiri
+      twitter-text
+
+PLATFORMS
+  aarch64-linux
+  arm-linux
+  arm64-darwin
+  x86-linux
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  RedCloth
+  activesupport (~> 7.1.3.4)
+  asciidoctor (~> 2.0.5)
+  commonmarker!
+  creole (~> 0.3.6)
+  github-linguist (>= 7.1.3)
+  github-markup!
+  html-pipeline (~> 1.0)
+  kramdown
+  minitest (~> 5.4, >= 5.4.3)
+  nokogiri (~> 1.16.5)
+  nokogiri-diff (~> 0.3.0)
+  org-ruby (= 0.9.9)
+  rake
+  rdoc (~> 6.7.0)
+  redcarpet
+  rexml
+  sanitize (>= 4.6.3)
+  twitter-text (~> 1.14)
+  wikicloth (= 0.8.3)
+
+BUNDLED WITH
+   2.5.9


### PR DESCRIPTION
Closes #1756

- [x] update github actions to latest versions
- [x] use SHAs instead of tags for github actions, more secure supply chain
- [x] add dependabot file grouping minor/patch dependency updates to reduce PRs
- [x] remove Gemfile.lock from .gitignore and add it back to source control
  - this will allow dependabot to detect dependency updates