### PR TITLE
chore: use sha instead of tag on stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'


### PR DESCRIPTION
didn't catch this in #1821

Using SHA instead of tag ensures secure supply chain.  Tags are mutable, SHAs are not