### PR TITLE
fix: ensure rubygems url is using https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gemspec
 
 gem "redcarpet", :platforms => :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
     github-markup (5.0.1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     RedCloth (4.3.4)
     activesupport (7.1.3.4)


### PR DESCRIPTION
Fixes `Dependency source URL uses the unencrypted protocol HTTP. Use HTTPS instead.`