### PR TITLE
feat: add djot parsing (DRAFT)

### DIFF
--- a/lib/github/commands/djot2html
+++ b/lib/github/commands/djot2html
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Djot2html -- Simple script to render a djot file to HTML!
+
+djot -f djot -t html $1

--- a/lib/github/markup.rb
+++ b/lib/github/markup.rb
@@ -20,6 +20,7 @@ module GitHub
     MARKUP_RST = :rst
     MARKUP_TEXTILE = :textile
     MARKUP_POD6 = :pod6
+    MARKUP_DJOT = :djot
   end
 
   module Markup

--- a/lib/github/markups.rb
+++ b/lib/github/markups.rb
@@ -57,3 +57,11 @@ command(
 
 command(::GitHub::Markups::MARKUP_POD6, :pod62html, /pod6/, ["Pod 6"], "pod6")
 command(::GitHub::Markups::MARKUP_POD, :pod2html, /pod/, ["Pod"], "pod")
+
+command(
+  ::GitHub::Markups::MARKUP_DJOT,
+  "python3 #{Shellwords.escape(File.dirname(__FILE__))}/commands/djot2html",
+  /dj|djot/,
+  ["Djot"],
+  "djot"
+)

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,3 +6,4 @@ cd $(dirname "$0")/..
 
 bundle install
 pip3 install docutils
+npm install -g @djot/djot


### PR DESCRIPTION
> **NOTE:** I'm looking for feedback on this PR! This is my first time using Ruby :)

This PR aims to add support for [djot](https://github.com/jgm/djot) HTML rendering for READMEs and whatnot.

[There](https://github.com/jgm/djot.lua) [are](https://github.com/aarroyoc/djota) [many](https://github.com/hellux/jotdown) [different](https://github.com/sivukhin/godjot) [implementations](https://github.com/jgm/djoths) of the parser, but none of them are in Ruby unfortunately.

The best one I think we should use is [djot.js](https://github.com/jgm/djot.js), which is the most "official" parser for djot.

What I probably need to add still:

- [ ] tests for djot
- [ ] guarantee that node/npm is installed for users using github markup?

I will need some advice on how this is done in this repo. Any help is much appreciated!