### PR TITLE
chore: add .venv/venv to .gitignore and update README with local dev info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ pkg/
 *~
 vendor/
 .DS_Store
+.venv
+venv

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ require 'github/markup'
 GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, "* One\n* Two")
 ```
 
+Local Development
+-----------------
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+cd script
+./bootstrap
+```
 
 Contributing
 ------------


### PR DESCRIPTION
best practices with local python development is to create a virtual environment.  The most common are either .venv or venv folders in the root of the repo.

We currently install [docutils](https://github.com/github/markup/blob/914839fd31c93b93a8054a3c91fce0906b2d1375/script/bootstrap#L8) via pip (python).

- [x] add .venv/venv folders to .gitignore
- [x] update README with how to setup locally environment