### PR TITLE
fix: stale issue/pr message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,27 +1,25 @@
-# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
-#
-# You can adjust the behavior by modifying this file.
-# For more information, see:
-# https://github.com/actions/stale
 name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '0 12 * * *'
+    - cron: "0 12 * * *"
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
 
     steps:
-    - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message'
-        stale-pr-message: 'Stale pull request message'
-        stale-issue-label: 'no-issue-activity'
-        stale-pr-label: 'no-pr-activity'
+      - uses: actions/stale@f7176fd3007623b69d27091f9b9d4ab7995f0a06 # v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed if no further activity occurs.
+            Thank you for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not
+            had recent activity. It will be closed if no further activity occurs.
+            Thank you for your contributions.


### PR DESCRIPTION
Make the stale issue/pr message better.

### Before

`Stale pull request message`

`Stale issue message`

### After

#### Issue

```
This issue has been automatically marked as stale because it has not
had recent activity. It will be closed if no further activity occurs.
Thank you for your contributions.
```

#### PR

```
This pull request has been automatically marked as stale because it has not
had recent activity. It will be closed if no further activity occurs.
Thank you for your contributions.
```