### PR TITLE
chore: add keep label to mark issues/prs from being marked as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,3 +23,5 @@ jobs:
             This pull request has been automatically marked as stale because it has not
             had recent activity. It will be closed if no further activity occurs.
             Thank you for your contributions.
+          exempt-issue-labels: keep
+          exempt-pr-labels: keep


### PR DESCRIPTION
- [x] added keep label to repo
- [x] add `exempt-issue-labels` and `exempt-pre-labels` to stale config