### PR TITLE
rest2html: treat referenced wrapped images in base document as inlined

### DIFF
--- a/lib/github/commands/rest2html
+++ b/lib/github/commands/rest2html
@@ -258,6 +258,12 @@ class GitHubHTMLTranslator(HTMLTranslator):
             self.body.append(self.starttag(node, 'img', **atts))
         HTMLTranslator.depart_image(self, node)
 
+        # treat images held in a reference on the base document as inlined
+        # images; this is to help avoid rendering a reference's decorative
+        # line for the spacing after an image
+        if (isinstance(node.parent, nodes.reference)
+            and isinstance(node.parent.parent, nodes.document)):
+            self.body.append(self.body.pop().rstrip('\n'))
 
 def kbd(name, rawtext, text, lineno, inliner, options={}, content=[]):
     return [nodes.raw('', '<kbd>%s</kbd>' % text, format='html')], []

--- a/test/markup_test.rb
+++ b/test/markup_test.rb
@@ -137,4 +137,16 @@ message
     assert_equal "&lt;style>.red{color: red;}&lt;/style>\n", GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, "<style>.red{color: red;}</style>", options: {commonmarker_opts: [:UNSAFE]})
     assert_equal "<style>.red{color: red;}</style>\n", GitHub::Markup.render_s(GitHub::Markups::MARKUP_MARKDOWN, "<style>.red{color: red;}</style>", options: {commonmarker_opts: [:UNSAFE], commonmarker_exts: [:autolink, :table, :strikethrough]})
   end
+
+  def test_blanks_rst_inlined_reference
+    expected = '<img src="https://example.com/img.svg"></a>'
+
+    actual = GitHub::Markup.render_s(GitHub::Markups::MARKUP_RST, <<~RST
+    .. image:: https://example.com/img.svg
+        :target: https://example.com/
+    RST
+    )
+
+    assert_equal expected, actual.strip.lines.last
+  end
 end


### PR DESCRIPTION
docutils will only add newlines around images it believes are inlined. For images held in references, it checks the parent of the reference if its a `TextElement` to consider it inlined. Since a document is not a `TextElement` type, it will wrap an image with newlines. For GitHub output, this is not desired and will result in the extra whitespace being rendered with a reference's decorative line. To avoid this, always strip any appended suffixes for images in this scenario.

----

There are a various GitHub projects which reveal the issue. For example, [Sphinx's `README.rst`](https://github.com/sphinx-doc/sphinx/blob/master/README.rst) shows this issue:

<kbd>
<img src="https://github.com/user-attachments/assets/36248550-e0da-4d44-97eb-3961b8b1d488">
</kbd>

With the changes made in this merge request, the following shows a rendering of HTML before and after the change:

<kbd>
<img src="https://github.com/user-attachments/assets/23db7a8f-24cd-4071-8a25-5ce832d21296">
</kbd>