### PR TITLE
fix: remediate supply chain security findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          # This should match lib/github/markups.rb GitHub::Markups::MARKUP_RST
+          # Required by lib/github/commands/rest2html (RST rendering)
           python-version: "3.x"
 
       - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 10
 
@@ -30,12 +30,12 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           # This should match lib/github/markups.rb GitHub::Markups::MARKUP_RST
           python-version: "3.x"
 
-      - uses: actions/cache@v5.0.4
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip
@@ -52,7 +52,9 @@ jobs:
           sudo cpanm --installdeps --notest Pod::Simple
 
       - name: Install Python dependencies
-        run: python -m pip install docutils
+        run: |
+          echo 'docutils==0.22.4 --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de' > /tmp/requirements.txt
+          python -m pip install -r /tmp/requirements.txt
 
       - name: Run rake
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN install-zef-as-user && zef install Pod::To::HTML
 RUN curl -L http://cpanmin.us | perl - App::cpanminus
 RUN cpanm --installdeps --notest Pod::Simple
 
-RUN echo 'docutils==0.18.1 --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c' > /tmp/requirements.txt && \
-    pip install -r /tmp/requirements.txt
+RUN pip install docutils==0.18.1
 
 ENV PATH $PATH:/root/.rbenv/bin:/root/.rbenv/shims
 RUN curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer | bash
@@ -27,7 +26,7 @@ RUN rbenv install 2.4.1
 RUN rbenv global 2.4.1
 RUN rbenv rehash
 
-RUN gem install bundler -v 2.4.10
+RUN gem install bundler -v 2.3.26
 
 WORKDIR /data/github-markup
 COPY github-markup.gemspec .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:trusty@sha256:64483f3496c1373bfd55348e88694d1c4d0c9b660dee6bfef5e12f43b9933b30 # trusty
 
 RUN apt-get update -qq
 RUN apt-get install -y apt-transport-https
@@ -18,7 +18,8 @@ RUN install-zef-as-user && zef install Pod::To::HTML
 RUN curl -L http://cpanmin.us | perl - App::cpanminus
 RUN cpanm --installdeps --notest Pod::Simple
 
-RUN pip install docutils
+RUN echo 'docutils==0.22.4 --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de' > /tmp/requirements.txt && \
+    pip install -r /tmp/requirements.txt
 
 ENV PATH $PATH:/root/.rbenv/bin:/root/.rbenv/shims
 RUN curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer | bash
@@ -26,7 +27,7 @@ RUN rbenv install 2.4.1
 RUN rbenv global 2.4.1
 RUN rbenv rehash
 
-RUN gem install bundler
+RUN gem install bundler -v 2.4.10
 
 WORKDIR /data/github-markup
 COPY github-markup.gemspec .

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN install-zef-as-user && zef install Pod::To::HTML
 RUN curl -L http://cpanmin.us | perl - App::cpanminus
 RUN cpanm --installdeps --notest Pod::Simple
 
-RUN echo 'docutils==0.22.4 --hash=sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de' > /tmp/requirements.txt && \
+RUN echo 'docutils==0.18.1 --hash=sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c' > /tmp/requirements.txt && \
     pip install -r /tmp/requirements.txt
 
 ENV PATH $PATH:/root/.rbenv/bin:/root/.rbenv/shims

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,4 +138,4 @@ DEPENDENCIES
   wikicloth (= 0.8.3)
 
 BUNDLED WITH
-   2.4.10
+   2.3.26


### PR DESCRIPTION
## Summary

Remediates 4 high-severity supply chain code scanning findings tracked in [vuln-mgmt#195573](https://github.com/github/vuln-mgmt/issues/195573).

## Changes

### Dockerfile
- **Pin Docker base image to SHA256 digest** ([code-scanning/14](https://github.com/github/markup/security/code-scanning/14)): `ubuntu:trusty` → `ubuntu:trusty@sha256:64483f...`
- **Pin bundler to exact version** ([code-scanning/16](https://github.com/github/markup/security/code-scanning/16)): `gem install bundler` → `gem install bundler -v 2.3.26` (last version compatible with the Dockerfile's Ruby 2.4.1; Gemfile.lock `BUNDLED WITH` updated to match)
- **Pin docutils version** ([code-scanning/15](https://github.com/github/markup/security/code-scanning/15)): `pip install docutils` → `pip install docutils==0.18.1` (last Python 2-compatible release, matching the Dockerfile's Python 2 environment)

### CI workflow (`.github/workflows/ci.yml`)
- **Add pip hash verification** ([code-scanning/12](https://github.com/github/markup/security/code-scanning/12)): `python -m pip install docutils` → pinned `docutils==0.22.4` with `--hash` verification via requirements file. Uses 0.22.4 (latest) since CI runs Python 3.x.
- **Pin GitHub Actions to commit SHAs**: `actions/checkout` (v6.0.2), `actions/setup-python` (v6.2.0), `actions/cache` (v5.0.4) — all pinned to full SHAs with version comments. `ruby/setup-ruby` was already SHA-pinned.
- **Fix inline comment**: Updated Python version comment to reference the actual dependency (`rest2html` script) instead of the `MARKUP_RST` Ruby constant.

### Notes
- Hash verification is used in CI (modern pip) but not in the Dockerfile (Trusty ships pip ~1.5, which predates `--hash` support added in pip 8.0). Version pinning alone addresses the code scanning finding for the Dockerfile.
- The Dockerfile is legacy (Ubuntu Trusty / Python 2 / Ruby 2.4.1) and is likely not actively built. Changes are safe — they pin existing dependencies without changing behavior.
- All action SHAs verified against upstream tags via `git ls-remote`.

## Testing

- CI passes across the full Ruby 3.2 / 3.3 / 3.4 test matrix (all 6 test jobs pass)
- CodeQL analysis passes for actions, python, and ruby
- submit-pypi check passes
- Multi-model code review (Opus, Sonnet, Haiku) conducted; Copilot PR reviewer feedback addressed in follow-up commit