### PR TITLE
fix: use HTTPS for cpanminus download in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install perl rakudo-pkg
 
-          curl -L http://cpanmin.us | perl - --sudo App::cpanminus
+          curl -fsSL https://cpanmin.us | perl - --sudo App::cpanminus
           sudo cpanm --installdeps --notest Pod::Simple
 
       - name: Install Python dependencies


### PR DESCRIPTION
## Summary

Switches the cpanminus download in CI from plain HTTP to HTTPS, closing a MITM attack vector.

Fixes #2049

## Changes

- `.github/workflows/ci.yml:51`: `curl -L http://cpanmin.us` → `curl -fsSL https://cpanmin.us`
  - `https://` prevents network attackers from injecting malicious code
  - `-f` fails fast on HTTP errors instead of piping error pages to perl
  - `-sS` suppresses progress but shows errors

## Testing

- CI runs on this PR validate that cpanminus installs correctly over HTTPS and all tests pass across Ruby 3.2/3.3/3.4.