### PR TITLE
chore: bump minimum Ruby to 3.3 and add Ruby 4.0 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
+          - "4.0"
       fail-fast: false
 
     steps:

--- a/github-markup.gemspec
+++ b/github-markup.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage      = "https://github.com/github/markup"
   s.license       = "MIT"
 
-  s.required_ruby_version = '>= 3.1.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.files         = `git ls-files`.split($\)
   s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
## Summary

Drops support for EOL Ruby versions and adds Ruby 4.0 to CI.

- **Ruby 3.1**: EOL March 2025 (already removed from CI matrix)
- **Ruby 3.2**: EOL March 2026
- **Ruby 4.0**: Released, now in full support

## Changes

- `github-markup.gemspec`: `required_ruby_version` bumped from `>= 3.1.0` to `>= 3.3.0`
- `.github/workflows/ci.yml`: Test matrix updated from `[3.2, 3.3, 3.4]` to `[3.3, 3.4, 4.0]`

## Testing

- CI runs on this PR validate compatibility across Ruby 3.3, 3.4, and 4.0.
- Ruby 4.0 is the key one to watch — first time this gem runs against a Ruby major version bump.